### PR TITLE
Improvements to Build Status index.html page

### DIFF
--- a/source/build_status/index.md
+++ b/source/build_status/index.md
@@ -107,7 +107,7 @@ In this case you have to do the following:
 * Run `sdkmanager` from your machine and install the latest Android SDKs;
 * *Optional:* If you want to use AVD (Android Virtual Device, emulator), please, check [this documentation](https://developer.android.com/studio/run/emulator);
 * *Optional:* If you don't like AVD, you can also use [Genymotion](https://genymotion.com);
-* Execute `react-native run-android`.
+* Execute `make run-android`.
 
 Errors like `android-sdk-16 not found` usually mean that you simply need to install missing SDKs. Run `sdkmanager` for that.
 

--- a/source/build_status/index.md
+++ b/source/build_status/index.md
@@ -4,7 +4,7 @@ id: index
 title: Build Status Yourself
 ---
 
-# #Build Status Yourself and Particpate in a Better Web
+# #Buidl Status Yourself and Particpate in a Better Web
 
 ## The easiest way
 

--- a/source/build_status/index.md
+++ b/source/build_status/index.md
@@ -169,3 +169,15 @@ cd node_modules/react-native/third-party/glog-0.3.4/ && ../../scripts/ios-config
 ```
 
 Now you should be able to compile again. The issue reference is [here](ttps://github.com/facebook/react-native/issues/21168#issuecomment-422431294).
+
+### I get a compilation error when running `clj -R:dev build.clj watch`
+
+Some developers see the error `Exception in thread "main" java.lang.NoSuchFieldError: VAR, compiling:((..)/status-react/build.clj:1:1)` when running the `clj -R:dev buid.clj watch` command (e.g., via `make startdev-android-avd`).
+
+This happens when you are running an earlier version of Clojure that is incompatible with `cljs.build.api`. The solution is to upgrade to the latest version of Clojure. E.g., for macOS
+
+```
+$ brew upgrade clojure
+==> Upgrading 1 outdated package:
+clojure 1.9.0.302 -> 1.9.0.397
+```

--- a/source/build_status/index.md
+++ b/source/build_status/index.md
@@ -4,7 +4,7 @@ id: index
 title: Build Status Yourself
 ---
 
-# #Buidl Status Yourself and Particpate in a Better Web
+# #Build Status Yourself and Particpate in a Better Web
 
 ## The easiest way
 
@@ -40,7 +40,7 @@ This script prepares and installs the following:
 * Maven
 * Cocoapods
 
-*Note 1:* it can take up to 20 minutes depending on your machine and internet connection speed.
+*Note 1:* It can take up to 20 minutes depending on your machine and internet connection speed.
 
 *Note 2:* If you don't have `nvm`, `node@8` will be installed from Homebrew.
 If you don't have `nvm` AND already have `node` installed on your machine then nothing will happen.
@@ -134,7 +134,7 @@ nvm use status-im
 
 ### Custom Android SDK location
 
-Some of developers prefer to use Android SDK integrated to Android Studio. Of course, it doesn't matter
+Some developers prefer to use Android SDK integrated in Android Studio. Of course, it doesn't matter
 for the build process — just make sure that `ANDROID_SDK_ROOT` points to a right location and you have all the SDKs installed.
 
 ## Troubleshooting
@@ -149,7 +149,7 @@ One of the best ways to install any older version of Node.js is to use `nvm`.
 Some developers are experiencing errors compiling for iOS on Xcode 10 on MacOs Mojave:
 
 ```
-error: Build input file cannot be found:  
+error: Build input file cannot be found:
 
 'status-react/node_modules/react-native/third-party/double-conversion-1.1.6/src/cached-powers.cc'
 ```

--- a/source/build_status/index.md
+++ b/source/build_status/index.md
@@ -4,7 +4,7 @@ id: index
 title: Build Status Yourself
 ---
 
-# #Buidl Status Yourself and Particpate in a Better Web
+# #Buidl Status Yourself and Participate in a Better Web
 
 ## The easiest way
 


### PR DESCRIPTION
This adds some information that would have helped me to get `status-react` up and running locally quicker. In the Riot #dev-status chat it was stated that at least one other person came across the `NoSuchFieldError: VAR` problem. And the `react-native run-android` command leads to runtime error.  The PR also contains some boyscouting that fixes typos and formatting.

Commits:

-  Fix minor typos
-  Add troubleshooting section on NoSuchFieldError: VAR error because of old Clojure version.
-  Correct command to start for Android

    make run-android adds necessary flag to react-native run-android:

    Makefile
    ```
    run-android: ##@run Run Android build
            react-native run-android --appIdSuffix debug
    ```

    Without this flag the compilation fails with `Activity class
    {im.status.ethereum/im.status.ethereum.MainActivity} does not exist.`