### PR TITLE
Fixed three typos

### DIFF
--- a/source/build_status/index.md
+++ b/source/build_status/index.md
@@ -4,7 +4,7 @@ id: index
 title: Build Status Yourself
 ---
 
-# #Buidl Status Yourself and Particpate in a Better Web
+# #Build Status Yourself and Participate in a Better Web
 
 ## The easiest way
 
@@ -168,4 +168,4 @@ cd node_modules/react-native/scripts && ./ios-install-third-party.sh && cd ../..
 cd node_modules/react-native/third-party/glog-0.3.4/ && ../../scripts/ios-configure-glog.sh && cd ../../../../
 ```
 
-Now you should be able to compile again. The issue reference is [here](ttps://github.com/facebook/react-native/issues/21168#issuecomment-422431294).
+Now you should be able to compile again. The issue reference is [here](https://github.com/facebook/react-native/issues/21168#issuecomment-422431294).


### PR DESCRIPTION
Fixed three typos, two in the headline and one in the "issue reference" link at the end of the page.