### PR TITLE
add Gulp task to download newest nightly links

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,6 +15,7 @@ let cleanCSS = require('gulp-clean-css');
 var rename = require("gulp-rename");
 
 const gen_qr = require('./scripts/gen-qr');
+const nightlies = require('./scripts/nightlies');
 
 // generate html with 'hexo generate'
 var hexo = new Hexo(process.cwd(), {});
@@ -95,6 +96,10 @@ gulp.task('compress', ['sass'], function() {
         .pipe(gulp.dest('./public/css/'));
 });
 
+gulp.task('nightlies', function() {
+    return nightlies()
+})
+
 gulp.task('genqr', function() {
     gen_qr()
 })
@@ -116,7 +121,7 @@ gulp.task('watch', function() {
 });
 
 gulp.task('build', function(cb) {
-    runSequence('generate', 'compress', 'bundle', 'genqr', 'watch')
+    runSequence('nightlies', 'generate', 'compress', 'genqr', 'bundle', 'watch')
 });
 
 gulp.task('exit', function(cb) {
@@ -124,7 +129,7 @@ gulp.task('exit', function(cb) {
 });
 
 gulp.task('run', function(cb) {
-    runSequence('generate', 'compress', 'bundle', 'genqr', 'exit')
+    runSequence('nightlies', 'generate', 'compress', 'genqr', 'bundle', 'exit')
     
 });
 

--- a/scripts/gen-qr.js
+++ b/scripts/gen-qr.js
@@ -14,10 +14,10 @@ const gen_qr = () => {
   var nightlies_file = fs.readFileSync(nightlies_path, 'utf8')
   var nightlies = yml.safeLoad(nightlies_file)
   
-  //log(qr_path + 'qr-apk.png (' + nightlies['APK_URL'] + ')')
-  qrc.toFile(qr_path + 'qr-apk.png', nightlies['APK_URL'], {}, err_handler)
-  //log(qr_path + 'qr-ios.png (' + nightlies['IOS_URL'] + ')')
-  qrc.toFile(qr_path + 'qr-ios.png', nightlies['IOS_URL'], {}, err_handler)
+  //log(qr_path + 'qr-apk.png (' + nightlies['APK'] + ')')
+  qrc.toFile(qr_path + 'qr-apk.png', nightlies['APK'], {}, err_handler)
+  //log(qr_path + 'qr-ios.png (' + nightlies['IOS'] + ')')
+  qrc.toFile(qr_path + 'qr-ios.png', nightlies['IOS'], {}, err_handler)
 }
 
 module.exports = gen_qr

--- a/scripts/nightlies.js
+++ b/scripts/nightlies.js
@@ -1,0 +1,31 @@
+const fs  = require('fs')
+const yml = require('js-yaml')
+const log = require('fancy-log')
+const err = log.error
+const request = require('request')
+
+const nightliesFile = 'source/_data/nightlies.yml'
+const bucketUrl = 'https://status-im.ams3.digitaloceanspaces.com'
+const latestUrl = `${bucketUrl}/latest.json`
+
+const nightlies = () => {
+  return new Promise((resolve, reject) => {
+    request(latestUrl, {json: true},
+      (err, res) => {
+        if (err) { throw err }
+        if (res.statusCode != 200) {
+          log(`URL: ${res.request.href}`)
+          err(`Error: ${res.statusCode} ${res.statusMessage} - ${res.explanation}`)
+          log('Unable to download latest nightlies, using default.')
+          resolve()
+        }
+        yamlText = yml.safeDump(res.body, {lineWidth: 200})
+        fs.writeFileSync(nightliesFile, yamlText)
+        log(`Saved to: ${nightliesFile}`)
+        resolve()
+      }
+    )
+  })
+}
+
+module.exports = nightlies

--- a/source/_data/nightlies.yml
+++ b/source/_data/nightlies.yml
@@ -1,4 +1,5 @@
-APK_URL: 'https://status-im.ams3.digitaloceanspaces.com/StatusIm-181107-131145-43075c-nightly.apk'
-IOS_URL: 'https://i.diawi.com/C1SPoU'
-NIX_URL: 'https://status-im.ams3.digitaloceanspaces.com/StatusIm-181107-131145-43075c-nightly.AppImage'
-DMG_URL: 'https://status-im.ams3.digitaloceanspaces.com/StatusIm-181107-131145-43075c-nightly.dmg'
+# WARNING: This file is updated by the 'nightlies' Gulp task during build
+APK: 'https://status-im.ams3.digitaloceanspaces.com/StatusIm-181110-145010-d2160e-nightly.apk'
+IOS: 'https://i.diawi.com/JQ4eVd'
+APP: 'https://status-im.ams3.digitaloceanspaces.com/StatusIm-181110-145010-d2160e-nightly.AppImage'
+MAC: 'https://status-im.ams3.digitaloceanspaces.com/StatusIm-181110-145010-d2160e-nightly.dmg'

--- a/themes/navy/layout/nightly.swig
+++ b/themes/navy/layout/nightly.swig
@@ -52,35 +52,35 @@
                     <div class="nightly-builds-wrap">
                         <div class="box">
                             <h2>Linux</h2>
-                            <a href="{{ site.data.nightlies['NIX_URL'] }}" target="_blank">
+                            <a href="{{ site.data.nightlies['APP'] }}" target="_blank">
                                 <img src="../nightly/img/linux.png" width="150" />
                                 <br><br>
-                                <span>{{ site.data.nightlies['NIX_URL'] | split('/') | last }}</span>
+                                <span>{{ site.data.nightlies['APP'] | split('/') | last }}</span>
                             </a>
                         </div>
                         <div class="box">
                             <h2>macOS</h2>
-                            <a href="{{ site.data.nightlies['DMG_URL'] }}" target="_blank">
+                            <a href="{{ site.data.nightlies['MAC'] }}" target="_blank">
                                 <img src="../nightly/img/macos.png" width="150" />
                                 <br><br>
-                                <span>{{ site.data.nightlies['DMG_URL'] | split('/') | last }}</span>
+                                <span>{{ site.data.nightlies['MAC'] | split('/') | last }}</span>
                             </a>
                         </div>
                         <div class="clear"></div>
                         <div class="box">
                             <h2>Android</h2>
-                            <a href="{{ site.data.nightlies['APK_URL'] }}" target="_blank">
+                            <a href="{{ site.data.nightlies['APK'] }}" target="_blank">
                                 <img src="../nightly/img/qr-apk.png" width="80%" />
                                 <br><br>
-                                <span>{{ site.data.nightlies['APK_URL'] | split('/') | last }}</span>
+                                <span>{{ site.data.nightlies['APK'] | split('/') | last }}</span>
                             </a>
                         </div>
                         <div class="box">
                             <h2>iOS</h2>
-                            <a href="{{ site.data.nightlies['IOS_URL'] }}" target="_blank">
+                            <a href="{{ site.data.nightlies['IOS'] }}" target="_blank">
                                 <img src="../nightly/img/qr-ios.png" width="80%" />
                                 <br><br>
-                                <span>{{ site.data.nightlies['IOS_URL'] }}</span>
+                                <span>{{ site.data.nightlies['IOS'] }}</span>
                             </a>
                             <small>(Requires diawi access)</small>
                         </div>


### PR DESCRIPTION
This is continuation of work started in: https://github.com/status-im/status.im/pull/128

The currentl nightl builds upload a JSON file to the bucket with the newest nightly URLs:
```
 % curl -sk https://status-im.ams3.digitaloceanspaces.com/latest.json
{
  "APK": "https://status-im.ams3.digitaloceanspaces.com/StatusIm-181110-145010-d2160e-nightly.apk",
  "IOS": "https://i.diawi.com/JQ4eVd",
  "APP": "https://status-im.ams3.digitaloceanspaces.com/StatusIm-181110-145010-d2160e-nightly.AppImage",
  "MAC": "https://status-im.ams3.digitaloceanspaces.com/StatusIm-181110-145010-d2160e-nightly.dmg"
}
```