### PR TITLE
include react-native-cli via npm install in list of steps for locally…

### DIFF
--- a/source/build_status/desktop.md
+++ b/source/build_status/desktop.md
@@ -34,6 +34,7 @@ Run the following commands to build a Desktop package for the host environment (
 ``` bash
 git clone https://github.com/status-im/status-react.git
 cd status-react
+npm install -g react-native-cli
 make prepare-desktop
 make release-desktop
 ```


### PR DESCRIPTION
… building a desktop release package

I'm not sure if we want to include this in the list of steps the user should take or elsewhere in the setup process, but at the very least I wanted to flag that `make release-desktop` will fail without some local `react-native` to fall back on, producing output including:

```
Generating Status.jsbundle and assets folder...
scripts/build-desktop.sh: line 107: react-native: command not found
Makefile:83: recipe for target 'release-desktop' failed
make: *** [release-desktop] Error 127
```

I know for development environment setup we install react-native-cli directly from the `react-native-desktop` repo so that could be another option. 