### PR TITLE
Replace `npm` with `yarn` in the desktop/mobile guide.

### DIFF
--- a/source/build_status/desktop.md
+++ b/source/build_status/desktop.md
@@ -9,7 +9,8 @@ title: Build Desktop
 
 You will need the following tools installed:
   - Clojure CLI tool `clj` https://clojure.org/guides/getting_started#_installation_on_mac_via_code_brew_code
-  - Node.js v.8.9.4, npm 5.5.1 (can be installed via `npm install -g npm@5.5.1`)
+  - Node.js v.8.9.4
+  - yarn 1.12.3 (can be installed via `npm install -g yarn@1.12.3`)
   - CMake 3.1.0 or higher
   - Additional packages: `extra-cmake-modules`; Keychain access on `Linux` requires `libgnome-keyring0`.
     - Linux: `sudo apt install extra-cmake-modules libgnome-keyring0`

--- a/source/build_status/desktop_troubleshooting.md
+++ b/source/build_status/desktop_troubleshooting.md
@@ -6,7 +6,7 @@ title: Troubleshooting
 ## Initial setup issues
 
 ### `npm install` hangs
-Downgrade to version 5.5.1: `npm install -g npm@5.5.1`.
+Use yarn instead. `npm install -g yarn@1.12.3` and use `yarn install`.
 
 ### `re-natal` missing
 Create a link:

--- a/source/build_status/index.md
+++ b/source/build_status/index.md
@@ -34,6 +34,7 @@ This script prepares and installs the following:
 * Java 8 (from Homebrew on Mac and from `ppa:webupd8team/java` on Ubuntu)
 * Clojure and Leiningen
 * Node.js (see note below)
+* yarn 1.12.3
 * React Native CLI and Watchman
 * Android SDK
 * Android NDK r10e (under `~/Android/Sdk/`)
@@ -44,7 +45,7 @@ This script prepares and installs the following:
 
 *Note 2:* If you don't have `nvm`, `node@8` will be installed from Homebrew.
 If you don't have `nvm` AND already have `node` installed on your machine then nothing will happen.
-Type `npm version` and make sure you don't use Node.js v10 because it's not supported by Realm.js (see **Troubleshooting** section for additional details).
+Type `node -v` and make sure you don't use Node.js v10 because it's not supported by Realm.js (see **Troubleshooting** section for additional details).
 
 ## Running development processes
 


### PR DESCRIPTION
Since we are switching to `yarn` for Desktop and mobile, updating the docs accordingly.

fixes: #51