### PR TITLE
Make QR boxes the same size as other platforms icons. Fixes #190

### DIFF
--- a/themes/navy/layout/nightly.swig
+++ b/themes/navy/layout/nightly.swig
@@ -80,7 +80,7 @@
                         <div class="box-mobile">
                             <h2>Android</h2>
                             <a href="{{ site.data.nightlies['APK'] }}" class="nightly-download" id="apk" download>
-                                <img src="../nightly/img/qr-apk.png" width="80%" />
+                                <img src="../nightly/img/qr-apk.png" width="150px" />
                                 <br><br>
                                 <span>{{ site.data.nightlies['APK'] | split('/') | last }}</span>
                             </a>
@@ -88,7 +88,7 @@
                         <div class="box-mobile">
                             <h2>iOS</h2>
                             <a href="{{ site.data.nightlies['IOS'] }}" class="nightly-download" id="ios" download>
-                                <img src="../nightly/img/qr-ios.png" width="80%" />
+                                <img src="../nightly/img/qr-ios.png" width="150px" />
                                 <br><br>
                                 <span>{{ site.data.nightlies['IOS'] }}</span>
                             </a>


### PR DESCRIPTION
This PR makes the QR boxes the same size as the icons for other platforms. Ona mobile screen it won't occupy the full width, but it won't look ugly either. On desktop it will look like this:

![image](https://user-images.githubusercontent.com/138074/49959690-a0f78080-ff0e-11e8-8118-ce6fc4837fc3.png)
