### PR TITLE
[WIP] Update links and styles to prepare for desktop release

### DIFF
--- a/themes/navy/layout/get_desktop.ejs
+++ b/themes/navy/layout/get_desktop.ejs
@@ -7,20 +7,32 @@
       <div class="get-status-desktop">
         <div class="get-status-desktop-links">
           <ul>
-            <li><a href="https://status-im.ams3.digitaloceanspaces.com/StatusIm-181025-083129-0bc9fb-nightly.dmg" class="desktop-link desktop-link--mac link-arrow">Get for Mac OS</a></li>
-            <li><a href="https://status-im.ams3.digitaloceanspaces.com/StatusIm-181025-083129-0bc9fb-nightly.AppImage" class="desktop-link desktop-link--linux link-arrow">Get for Linux</a></li>
-            <li><span class="desktop-link desktop-link--windows link-arrow desktop-link--disabled">Get for Windows</span></li>
+            <li><a href="https://ci.status.im/job/status-react/job/combined/job/desktop-macos/4971/artifact/StatusImPackage/StatusIm-181224-165548-797a3a-release.dmg" class="desktop-link desktop-link--mac link-arrow">Get for Mac OS</a></li>
+            <li><a href="https://ci.status.im/job/status-react/job/combined/job/desktop-linux/4958/artifact/StatusImPackage/StatusIm-181224-165548-797a3a-release.AppImage" class="desktop-link desktop-link--linux link-arrow">Get for Linux</a></li>
+            <li><a href="https://ci.status.im/job/status-react/job/combined/job/desktop-windows/1443/artifact/StatusImPackage/StatusIm-181224-165548-797a3a-release.exe" class="desktop-link desktop-link--windows link-arrow">Get for Windows</a></li>
           </ul>
         </div>
+        <div class="get-status-desktop-warning">
+          <p>This is alpha software and may contain vulnerabilities. Please expect changes.</p>
+        </div>
         <div class="get-status-desktop-mobile-links">
-          <a class="button" href="#">
+          <a class="button" href="https://ci.status.im/job/status-react/job/combined/job/desktop-macos/4971/artifact/StatusImPackage/StatusIm-181224-165548-797a3a-release.">
               <span class="button-icon button-icon--ios"></span>
               Get Status for Mac OS
           </a>
-          <a class="button" href="#">
+          <a class="button" href="https://ci.status.im/job/status-react/job/combined/job/desktop-linux/4958/artifact/StatusImPackage/StatusIm-181224-165548-797a3a-release.AppImage">
               <span class="button-icon button-icon--linux"></span>
               Get Status for Linux
           </a>
+          <a class="button" href="https://ci.status.im/job/status-react/job/combined/job/desktop-windows/1443/artifact/StatusImPackage/StatusIm-181224-165548-797a3a-release.exe">
+            <span class="button-icon button-icon--windows"></span>
+            Get Status for Windows
+          </a>
+        </div>
+        <div>
+          <div class="get-status-desktop-mobile-warning">
+            <p>This is alpha software and may contain vulnerabilities. Please expect changes.</p>
+          </div>
         </div>
         <div class="get-status-desktop-screen">
           <div class="get-status-desktop-screen-inner"></div>

--- a/themes/navy/layout/get_desktop.ejs
+++ b/themes/navy/layout/get_desktop.ejs
@@ -4,6 +4,10 @@
           <p>Because making Ethereum accessible from anywhere also means it should be easy to use from where you work.</p>
       </div>
 
+      <div class="get-status-desktop-warning">
+        <p>This is alpha software and may contain vulnerabilities. Please expect changes.</p>
+      </div>
+
       <div class="get-status-desktop">
         <div class="get-status-desktop-links">
           <ul>
@@ -12,7 +16,7 @@
             <li><a href="https://ci.status.im/job/status-react/job/combined/job/desktop-windows/1443/artifact/StatusImPackage/StatusIm-181224-165548-797a3a-release.exe" class="desktop-link desktop-link--windows link-arrow">Get for Windows</a></li>
           </ul>
         </div>
-        <div class="get-status-desktop-warning">
+        <div class="get-status-desktop-mobile-warning">
           <p>This is alpha software and may contain vulnerabilities. Please expect changes.</p>
         </div>
         <div class="get-status-desktop-mobile-links">
@@ -28,11 +32,6 @@
             <span class="button-icon button-icon--windows"></span>
             Get Status for Windows
           </a>
-        </div>
-        <div>
-          <div class="get-status-desktop-mobile-warning">
-            <p>This is alpha software and may contain vulnerabilities. Please expect changes.</p>
-          </div>
         </div>
         <div class="get-status-desktop-screen">
           <div class="get-status-desktop-screen-inner"></div>

--- a/themes/navy/layout/index.ejs
+++ b/themes/navy/layout/index.ejs
@@ -13,7 +13,7 @@
                 GET STATUS FOR ANDROID
             </a>
         </div>
-        <!-- div class="intro-under-buttons secondary-text">Or try out the <a href="/get_desktop/">Desktop App</a></div -->
+        <div class="intro-under-buttons secondary-text">Or try out the <a href="/get_desktop/">Desktop App</a></div>
     </div>
 </div>
 

--- a/themes/navy/source/scss/get-status-intro.scss
+++ b/themes/navy/source/scss/get-status-intro.scss
@@ -32,11 +32,13 @@
 	align-items: center;
 	display: flex;
 	flex-direction: column;
-	margin-bottom: 32px;
+	margin-top: 24px;
 	text-align: center;
 
 	p {
 		color: $colorGray;
+		font-size: 14px;
+		font-style: italic;
 	}
 }
 
@@ -315,8 +317,13 @@
 		margin: 0 0 16px 0;
 	}
 
-	.get-status-desktop-mobile-links{
+	.get-status-desktop-mobile-links {
 		margin: 16px 0 24px 0;
+	}
+
+	.get-status-desktop-mobile-warning {
+		margin-bottom: 12px;
+		margin-top: 4px;
 	}
 
 	.get-status-info {
@@ -445,6 +452,11 @@
 	.get-status-intro h1 {
   		font-size: 24px;
   		line-height: 1.4em;
+	}
+
+	.get-status-desktop-mobile-warning {
+		margin-bottom: 12px;
+		margin-top: 18px;
 	}
 
 	.get-status-desktop-screen {

--- a/themes/navy/source/scss/get-status-intro.scss
+++ b/themes/navy/source/scss/get-status-intro.scss
@@ -6,10 +6,10 @@
 	display: flex;
 	max-width: 760px;
 	padding: 0 32px;
-  align-items: center;
-  flex-direction: column;
-  text-align: center;
-  margin: 140px auto 0;
+	align-items: center;
+	flex-direction: column;
+	text-align: center;
+	margin: 140px auto 0;
 }
 
 .get-status-intro h2 {
@@ -28,16 +28,32 @@
 	margin: 0 auto;
 }
 
+.get-status-desktop-warning, .get-status-desktop-mobile-warning {
+	align-items: center;
+	display: flex;
+	flex-direction: column;
+	margin-bottom: 32px;
+	text-align: center;
+
+	p {
+		color: $colorGray;
+	}
+}
+
 .get-status-desktop-links {
 	padding: 24px 0;
 }
 
-.get-status-desktop-mobile-links {
+.get-status-desktop-mobile-links, .get-status-desktop-mobile-warning {
 	display: none;
 }
 
 .button-icon.button-icon--linux {
 	background-image: url(../img/icon-linux-blue-small.svg);
+}
+
+.button-icon.button-icon--windows {
+	background-image: url(../img/icon-windows-blue.svg);
 }
 
 .get-status-desktop-links ul {
@@ -287,15 +303,15 @@
 	    padding: 0 32px 32px;
 	}
 
-	.get-status-desktop-links {
+	.get-status-desktop-links, .get-status-desktop-warning {
 		display: none;
 	}
 
-	.get-status-desktop-mobile-links {
+	.get-status-desktop-mobile-links, .get-status-desktop-mobile-warning {
 		display: block;
 	}
 
-	.get-status-desktop-mobile-links .button:first-child {
+	.get-status-desktop-mobile-links .button:not(:last-child) {
 		margin: 0 0 16px 0;
 	}
 


### PR DESCRIPTION
Fixes #195 

- [x] I added the message about alpha but wasn't sure where to put it. Any ideas?
- [ ] It looks like we don't have a light blue version of the windows logo for the mobile version. Anyone have it?

### On larger screens:
<img width="864" alt="image" src="https://user-images.githubusercontent.com/27938023/50620605-4c856680-0ef8-11e9-939a-ed28fed3e2c2.png">

### When collapsing on smaller screens:
<img width="676" alt="image" src="https://user-images.githubusercontent.com/27938023/50620626-7f2f5f00-0ef8-11e9-8cd7-4c68769a62c6.png">

---

### Homepage:
<img width="671" alt="image" src="https://user-images.githubusercontent.com/27938023/50621173-14802280-0efc-11e9-9129-fc41fda6694a.png">

cc/ @pablanopete @rachelhamlin @richard-ramos @corpetty @PombeirP @andytudhope @jakubgs @flexsurfer @jeluard @andmironov 