### PR TITLE
Changed link to desktop FAQ

### DIFF
--- a/themes/navy/layout/nightly.ejs
+++ b/themes/navy/layout/nightly.ejs
@@ -48,7 +48,7 @@
                         <p><strong>Warning:</strong> Nightly builds are intended for development testing and may include bugs and other issues.</p>
                         <p>By downloading and installing these builds you assume the full responsibility for all risks concerning your data and funds.
                         Status makes no claims of security or integrity of funds in these builds. Status advises the use of different recovery phrases in nightlies and stable builds.</p>
-                        <a href="../build_status/desktop.html" target="_blank">Desktop FAQ</a>
+                        <a href="../docs/FAQ-desktop.html" target="_blank">Desktop FAQ</a>
                     </div>
                     <div class="nightly-builds-wrap">
                         <div class="box-desktop">


### PR DESCRIPTION
Changed link on the nightly page to point to correct Status Desktop FAQ