### PR TITLE
Add a release schedule for Status mobile apps

### DIFF
--- a/source/_data/sidebar.yml
+++ b/source/_data/sidebar.yml
@@ -17,6 +17,8 @@ docs:
     guides: ../guides/
   analytics:
     analytics_status: ../analytics/
+  mobile_release:
+    mobile_release_schedule: ../mobile-release-schedule/
 
 developer_tools:
   web3_for_everyone:

--- a/source/mobile-release-schedule/index.md
+++ b/source/mobile-release-schedule/index.md
@@ -1,0 +1,32 @@
+---
+title: Mobile Release Schedule
+comments: false
+---
+
+<script type="text/javascript">
+    var today = new Date();
+    var dd = String(today.getDate()).padStart(2, '0');
+    var mm = String(today.getMonth() + 1).padStart(2, '0'); //January is 0!
+    var yyyy = today.getFullYear();
+
+    var todayStr = yyyy + "-" + mm + "-" + dd;
+    document.write("Today: " + todayStr);
+</script>
+
+Our release process: [Mobile App Release Process @ status-react](https://github.com/status-im/status-react/blob/develop/doc/decisions/0009-release-process-mobile.md)
+
+## Release 0.11.0
+Planned date: 2019-03-26
+Feature freeze: 2019-03-20
+
+## Release 0.12.0
+Planned date: 2019-04-09
+Feature freeze: 2019-04-03
+
+## Release 0.13.0
+Planned date: 2019-04-23
+Feature freeze: 2019-04-17
+
+## Release 0.14.0
+Planned date: 2019-05-07
+Feature freeze: 2019-05-01

--- a/themes/navy/languages/en.yml
+++ b/themes/navy/languages/en.yml
@@ -35,6 +35,8 @@ sidebar:
     guides: Start Contributing
     analytics: Analytics  
     analytics_status: Analysing Status
+    mobile_release: Releases (Mobile)
+    mobile_release_schedule: Schedule
 
   build_status:
     build_status: Build Status Yourself


### PR DESCRIPTION
To increase transparency, from the Core Improvements Swarm.

And we are back to fixed 2 weeks release schedule because it bring much more clarity when interacting with other teams.