### PR TITLE
keycard api 2.2 docs

### DIFF
--- a/source/keycard_api/apdu_changelog.md
+++ b/source/keycard_api/apdu_changelog.md
@@ -5,6 +5,10 @@ title: Protocol
 
 # Changelog
 
+## Version 2.2
+* Added additional options to the SIGN command to facilitate usage in POS transactions.
+* Make SET NDEF more tolerant on the input format by automatically appending missing length.
+
 ## Version 2.1
 * Added concept of capabilities, making some APDU conditional and extending the SELECT response.
 

--- a/source/keycard_api/apdu_derivekey.md
+++ b/source/keycard_api/apdu_derivekey.md
@@ -11,7 +11,7 @@ title: Protocol
 * P2 = 0x00
 * Data = a sequence of 32-bit integers (most significant byte first). Empty if the master key must be used.
 * Response SW = 0x9000 on success, 0x6A80 if the format is invalid, 0x6984 if one of the components in the path generates an invalid key, 0x6B00 if derivation from parent keys is selected but no valid parent key is cached.
-* Preconditions: Secure Channel must be opened, user PIN must be verified (if no PIN-less key is defined), an extended keyset must be loaded
+* Preconditions: Secure Channel must be opened, user PIN must be verified, an extended keyset must be loaded
 
 This command is used before a signing session to generate a private key according to the [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) specifications. This command always aborts open signing sessions, if any. The generated key is used for all subsequent SIGN sessions. The maximum depth of derivation from the master key is 10. Any attempt to get deeper results in 0x6A80 being returned. The BIP32 specifications define a few checks which must be performed on the derived keys. If these fail, the 0x6984 is returned and the invalid key is discarded. A client should perform a GET STATUS command to get the actual current key path and resume derivation using a different path.
 

--- a/source/keycard_api/apdu_loadkey.md
+++ b/source/keycard_api/apdu_loadkey.md
@@ -30,4 +30,4 @@ If P1 is 0x01 or 0x02
   
 If P1 is 0x03 a 64 byte sequence generated according to the BIP39 specifications is expected. The master key will be generated according to the [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) specifications. This is only supported if the hardware supports public key derivation.
 
-This command is used to load or replace the keypair used for signing on the card. This command always aborts open signing sessions, if any. Unless a DERIVE KEY is sent, a subsequent SIGN command will use this keypair for signature.
+This command is used to load or replace the keypair used for signing on the card. The PIN-less path will be reset. Unless a DERIVE KEY is sent, a subsequent SIGN command will use this keypair for signature.

--- a/source/keycard_api/apdu_opensecurechannel.md
+++ b/source/keycard_api/apdu_opensecurechannel.md
@@ -23,3 +23,35 @@ The card generates a random 256-bit salt which is sent to the client. Both the c
 3. The output of the SHA-512 algorithm is split in two parts of 256-bit. The first part is used as the encryption key and the second part is used as the MAC key for further communication.
 
 The seed IV is used by the client as the IV for the next encrypted APDU.
+
+## Encrypted APDUs
+
+After a successful OPEN SECURE CHANNEL command all communication between card and client is encrypted. Note that only the data fields of C-APDU are encrypted, which means that CLA, INS, P1, P2 for C-APDU are plaintext. This means no sensitive data should be sent in these parameters. Additionally a MAC is calculated for the entire APDU, including the unencrypted fields.
+
+Because R-APDU can only contain data if their SW is a success or warning status word (0x9000, 0x62XX, 0x63XX), when the secure channel is open all responses will have SW 0x9000. The actual SW is always appended at the end of the response data before encryption, which means the client must interpret the last two bytes of the plaintext response as the SW. An exception to this is SW 0x6982, which indicates that the SecureChannel has been aborted and as such is returned without any MAC.
+
+To encrypt the data both the card and the client do the following:
+
+1. The data is padded using the ISO/IEC 9797-1 Method 2 algorithm.
+2. The data is encrypted using AES in CBC mode using the session key.
+3. An AES CBC-MAC is calculated over the entire APDU data
+4. The data field of the APDU is set to the MAC followed by the encrypted data.
+
+To decrypt the data both the card and the client do the following:
+
+1. The first 16 bytes of the APDU data are the MAC to be verified
+2. The remaining data is decrypted using AES in CBC mode using the session key.
+3. The padding is removed.
+
+The IV used for the encryption is the last seen MAC from the counterpart. This optimizes the number of transmitted bytes and guarantees protection from replay attacks. For the MAC generation, a zero IV is always used.
+
+MAC generation for C-APDUs is calculated on the concatenation of CLA INS P1 P2 LC 00 00 00 00 00 00 00 00 00 00 00 and the encrypted data field. The 11-byte long padding does not become part of the data field and does not affect LC
+
+MAC generation fo R-APDUs is calculated on the concatenation of Lr 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 and the encrypted data field. The 15-byte long padding does not become part of the response field. Lr is the length of the encrypted response data field and is not transmitted.
+
+Because AES in CBC mode requires the data field length in bytes to be a multiple of 16, the maximum effective APDU size becomes 240 bytes. Of these 16 bytes are used for the MAC and minimum of 1 byte for padding, making the maximum payload size in a single APDU 223 bytes, meaning about a 13,5% overhead.
+
+## Error conditions
+
+1. If a sensitive command is received without an active Secure Channel, the card shall respond with SW 0x6985 (SW_CONDITIONS_NOT_SATISFIED)
+2. If a MAC cannot be verified the card shall respond 0x6982 and the Secure Channel must be closed

--- a/source/keycard_api/apdu_pair.md
+++ b/source/keycard_api/apdu_pair.md
@@ -28,7 +28,7 @@ Response Data:
 
 This APDU is sent to pair a client. Pairing is performed with two commands which must be sent immediately one after the other. 
 
-In the first phase the client sends a random challenge to the card. The card replies with the SHA-256 hash of the challenge and the shared secret followed by its random challenge. The client is thus able to authenticate the card by verifying the card cryptogram (since the client can generate the same and verify that it matches).
+In the first phase the client sends a random challenge to the card. The card replies with the SHA-256 hash of the shared secret and the challenge followed by its random challenge. The client is thus able to authenticate the card by verifying the card cryptogram (since the client can generate the same and verify that it matches).
 
 In the second phase the client sends the client cryptogram which is the SHA-256 hash of the shared secret and the card challenge. The card verifies the cryptogram and thus authenticates the client. On success the card generates a random 256-bit salt which is appended to the shared secret. The SHA-256 hash of the concatenated value is stored in the first available pairing slot and will be further used to derive session keys. The card responds with the pairing index (which the client must send in all OPEN SECURE CHANNEL commands) and the salt used to generate the key, so that the client can generate and store the same key.
 

--- a/source/keycard_api/apdu_setndef.md
+++ b/source/keycard_api/apdu_setndef.md
@@ -10,10 +10,10 @@ title: Protocol
 * P1 = 0x00
 * P2 = 0x00
 * Data = the data to store
-* Response SW = 0x9000 on success, 0x6A80 on invalid data
+* Response SW = 0x9000 on success
 * Preconditions: Secure Channel must be opened, PIN must be verified
 * Capability: NDEF
 
 Used to set the content of the data file owned by the NDEF applet. This allows changing the behavior of Android and other clients when tapping the card with no open client. As an example, it could be used to launch a specific wallet software.
 
-The data is stored as is. A check is made that the first 2 bytes, read as a MSB first short, are equal to the Lc field minus 2 (the length of the field itself). This does not ensure that the NDEF record is valid, but ensures that no out of bound access happens.
+If the first 2 bytes, read as a MSB first short, are equal to the Lc field minus 2 (the length of the field itself) then the data is stored as is. Otherwise Lc is extended to a 16-bit value and appended to the stored data.

--- a/source/keycard_api/apdu_setpinlesspath.md
+++ b/source/keycard_api/apdu_setpinlesspath.md
@@ -13,4 +13,4 @@ title: Protocol
 * Response SW = 0x9000 on success, 0x6A80 if data is invalid
 * Preconditions: Secure Channel must be opened, user PIN must be verified
 
-Sets the given sequence of 32-bit integers as a PIN-less path. When the current derived key matches this path, SIGN will work even if no PIN authentication has been performed. An empty sequence means that no PIN-less path is defined.
+Sets the given sequence of 32-bit integers as a PIN-less path. When the current derived key matches this path, SIGN will work even if no PIN authentication or pairing has been performed. An empty sequence means that no PIN-less path is defined.

--- a/source/keycard_api/apdu_sign.md
+++ b/source/keycard_api/apdu_sign.md
@@ -7,12 +7,18 @@ title: Protocol
 
 * CLA = 0x80
 * INS = 0xC0
-* P1 = 0x00
+* P1 = derivation options
 * P2 = 0x00
-* Data = the hash to sign
+* Data = the hash to sign (32 bytes) | sequence of 32-bit integers (if P1=01 or P1=02)
 * Response = public key and the signature
-* Response SW = 0x9000 on success, 0x6A80 if the data is not 32-byte long
+* Response SW = 0x9000 on success, 0x6A80 if the data is less than 32-byte long (36 bytes if P1=01 or P1=02), 0x6A88 if P1=0x03 but no PIN-less path is defined
 * Preconditions: Secure Channel must be opened, user PIN must be verified (or a PIN-less key must be active), a valid keypair must be loaded
+
+P1:
+0x00 = Current key
+0x01 = Derive
+0x02 = Derive and make current
+0x03 = PIN-less path
 
 Response Data format:
 - Tag 0xA0 = signature template
@@ -22,3 +28,5 @@ Response Data format:
     - Tag 0x02 = S value
 
 Returns the ECDSA signature of the hash. The hash can be calculated using any algorithm, but must be 32-bytes long. The signature is returned in a signature template, containing the public key associated to the signature and the signature itself. For usage on the blockchain, you will need to calculate the recovery ID in addition to extracting R and S. To calculate the recovery ID you need to apply the same algorithm used for public key recovery from a transaction starting with a recovery ID of 0. If the public key matches the one returned in the template, then you have found the recovery ID, otherwise you try again by incrementing the recovery ID.
+P1 = 0x01 derives the path given in the data field without changing the current path of the card. P1 = 0x02 derives the path but also changes the current path of the card. The source for derivation can be set by OR'ing P1 with the constants defined in the DERIVE KEY command. This allows deriving from master, parent or current.
+P1 = 0x03 is specifically thought for POS transactions. It can be executed without Secure Channel (since no sensitive info is transmitted) and does not require PIN authentication. The current derivation path on the card remains unchanged, but the signing process is performed using the PIN-less derivation path previously defined using the SET PINLESS PATH command.

--- a/source/keycard_api/index.md
+++ b/source/keycard_api/index.md
@@ -19,4 +19,4 @@ If you use a different language, please first refer to the [Java SDK](sdk_instal
 
 ## Versioning
 
-The current version of the applet is 2.1. This documentation applies to said version. [Semantic versioning](https://semver.org) is used throughout the project, with the omission of the patch number for the applet, but not the SDK and related tools. The version of all components of the Keycard project are tied to the protocol version.
+The current version of the applet is 2.2. This documentation applies to said version. [Semantic versioning](https://semver.org) is used throughout the project, with the omission of the patch number for the applet, but not the SDK and related tools. The version of all components of the Keycard project are tied to the protocol version.


### PR DESCRIPTION
improve securechannel documentation

extend SIGN

relax securechannel requirements for the SIGN command

re-introduce P2 definition

reset PINless path on new load

correct parameter order

more tolerant SET NDEF