### PR TITLE
Bring SDK documentation to version 2.2

### DIFF
--- a/source/_data/sidebar.yml
+++ b/source/_data/sidebar.yml
@@ -76,6 +76,7 @@ keycard_api:
     sdk_authentication: sdk_authentication.html
     sdk_create_wallet: sdk_create_wallet.html
     sdk_derivation_sign: sdk_derivation_sign.html
+    sdk_pinless: sdk_payments.html
     sdk_export: sdk_export.html
     sdk_duplication: sdk_duplication.html
   apdu:

--- a/source/_data/sidebar.yml
+++ b/source/_data/sidebar.yml
@@ -76,7 +76,7 @@ keycard_api:
     sdk_authentication: sdk_authentication.html
     sdk_create_wallet: sdk_create_wallet.html
     sdk_derivation_sign: sdk_derivation_sign.html
-    sdk_pinless: sdk_payments.html
+    sdk_pinless: sdk_pinless.html
     sdk_export: sdk_export.html
     sdk_duplication: sdk_duplication.html
   apdu:

--- a/source/keycard_api/apdu_overview.md
+++ b/source/keycard_api/apdu_overview.md
@@ -9,10 +9,11 @@ This document describes all APDUs part of the Keycard APDU protocol. Any impleme
 
 ## Version
 
-This documentation is at version 2.1.
+This documentation is at version 2.2.
  
 ## Conventions
 
+* Bits are counted from 0. If this documentation talks mentions bit 7 it refers to the MSB of a byte.
 * When a command has a precondition clause and these are not met the Status Word 0x6985 is returned. 
 * When a command is unsupported the Status Word 0x6A81 is returned.
 * All tagged data structures are encoded in the [BER-TLV format](http://www.cardwerk.com/smartcards/smartcard_standard_ISO7816-4_annex-d.aspx).

--- a/source/keycard_api/sdk_derivation_sign.md
+++ b/source/keycard_api/sdk_derivation_sign.md
@@ -54,3 +54,14 @@ RecoverableSignature signature = new RecoverableSignature(hash, cmdSet.sign(hash
 ```
 
 Signing requires user authentication.
+
+## Combined derivation and sign
+
+Since version 2.2 of the Keycard API, it is possible to combine derivation and sign in a single step. Additionally, it is possible to choose whether the given path becomes the current path or not. Example
+
+```java
+// hash is the hash to sign, the second argument is the path to use, in the same format as for the DERIVE KEY command
+// the third argument is a flag indicating whether the derived key should become the current key or not
+APDUResponse resp = cmdSet.signWithPath(hash, "m/44'/0'/0'/0/0", false);
+RecoverableSignature signature = new RecoverableSignature(hash, resp.checkOK().getData());
+```

--- a/source/keycard_api/sdk_pinless.md
+++ b/source/keycard_api/sdk_pinless.md
@@ -1,0 +1,28 @@
+---
+id: sdk_pinless
+title: Java SDK
+---
+
+# Pinless signing
+
+The card offers the option to define a BIP32 path which can be used to sign transactions (or meta-transactions) without requiring a PIN. The **SIGN** command also has the option to sign with this pinless path (if defined) without having to know its value in advance. Since in such a scenario no sensitive data is being transferred, signing using the pinless path can be done without opening a Secure Channel.
+
+There are several scenarios made possible by this feature. One example, is the ability to use the card for payments at POS terminals. Pairing with every terminal is not practical and inserting the PIN on an untrusted device (the terminal is owned by a 3rd party) is not safe, since it could be logged. Pinless signing with no Secure Channel solves both issues.
+
+Since the wallet assigned to pinless signing is basically unprotected, it must not hold great value. One option is to consider the funds in that account like pocket cash. You put a little of your favourite cryptocurrency and should someone get hold of the card, you lost maybe the equivalent of $5. Another option, valid when using Ethereum, is to not hold any value in that wallet at all. Instead it can be used to sign meta-transactions and actual fund allocation can be handled by a smart contract through a dApp. Of course in this case the POS must be compatible with the specific payment scheme for this to work properly.
+
+## Defining a pinless path
+
+Defining which path is used for pinless signing, of course, requires PIN authentication and thus a Secure Channel. This means that only the owner can define which wallet is allocated for this operation. Then SDK call to set the pinless path is
+
+```java
+cmdSet.setPinlessPath("m/44'/0'/0'/0/200").checkOK();
+```
+
+## Signing with pinless path
+
+When a pinless path is defined, a wallet (or POS terminal, or whatever) can invoke the `signPinless` method without having to know the path. If no pinless path was defined, the Status Word 0x6A88 will be returned. As mentioned before, opening a Secure Channel and authenticating with PIN before sending this command is allowed but not necessary.
+
+```java
+cmdSet.signPinless(hashToSign).checkOK();
+```

--- a/themes/navy/languages/en.yml
+++ b/themes/navy/languages/en.yml
@@ -88,10 +88,11 @@ sidebar:
     sdk_authentication: User authentication
     sdk_create_wallet: Wallet creation
     sdk_derivation_sign: Derivation & signing
+    sdk_pinless: Pinless Signing
     sdk_export: Exporting keys
     sdk_duplication: Card duplication
     apdu: Protocol
-    apdu_overview: Ovierview
+    apdu_overview: Overview
     apdu_changelog: Changelog
     apdu_select: SELECT
     apdu_init: INIT


### PR DESCRIPTION
The protocol document was already up to date, but the SDK documentation was still missing the tutorial part for the extended SIGN command.