### PR TITLE
Add link to SNT Use Case to analytics page of docs

### DIFF
--- a/themes/navy/layout/analytics.ejs
+++ b/themes/navy/layout/analytics.ejs
@@ -24,7 +24,7 @@
                             <h2>User Analytics</h2>
                             <p class="analytics-list"><a href="./app_downloads.html">App Downloads</a></p>
                             <p class="analytics-list"><a href="./messages.html">Messages</a></p>
-                            <p class="analytics-list"><a href="./ens_registration.html">ENS Registrations</a></p>
+                            <p class="analytics-list"><a href="https://analytics.status.im/">SNT Use Cases</a></p>
                         </div>
                         <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
                         <div class="analytic-item-image" id="whisper-distinct-users-daily"></div>


### PR DESCRIPTION
updated analytics page in docs to remove link for ENS Registration and replace with link to new SNT use case dashboard 
https://analytics.status.im/