### PR TITLE
add Fathom analytics JS

### DIFF
--- a/_config.dev.yml
+++ b/_config.dev.yml
@@ -52,6 +52,9 @@ elasticsearch:
   esHost: 'search.status.im'
   esPort: 443
 
+# ID for Fathom Analytics
+fathom_site_id: 'QMOCY'
+
 math:
   engine: 'mathjax' # or 'katex'
   mathjax:

--- a/_config.prod.yml
+++ b/_config.prod.yml
@@ -52,6 +52,9 @@ elasticsearch:
   esHost: 'search.status.im'
   esPort: 443
 
+# ID for Fathom Analytics
+fathom_site_id: 'BMGJI'
+
 math:
   engine: 'mathjax' # or 'katex'
   mathjax:

--- a/source/app_downloads_counter.js
+++ b/source/app_downloads_counter.js
@@ -1,7 +1,0 @@
-/* This POSTs to the clicks-api service to click numbers of downloads of different releases */
-$(document).ready(function () {
-  $('a.app-download').click(function (ev) {
-    let downloadType = $(this).closest('a').attr('id')
-    $.post(`https://clicks.status.im/clicks/${downloadType}`)
-  });
-});

--- a/themes/navy/languages/en.yml
+++ b/themes/navy/languages/en.yml
@@ -641,8 +641,10 @@ site:
       nimbus: "Nimbus"
       keycard: "Keycard"
     connect: "Connect"
+    site-analytics: "Site Analytics"
     privacy-policy:
       title: "Privacy Policy"
+
       description: "Status Research & Development GmbH, Baarerstrasse 10, Zug, Switzerland"
   link:
     get-status: "Get Status"

--- a/themes/navy/languages/fr.yml
+++ b/themes/navy/languages/fr.yml
@@ -649,6 +649,7 @@ site:
       nimbus: Nimbus
       keycard: 'Carte d´accès'
     connect: Connectez-vous
+    site-analytics: "Analyse de site"
     privacy-policy:
       title: 'Politique de confidentialité'
       description: 'Status Research & Development GmbH, Baarerstrasse 10, Zug, Suisse'

--- a/themes/navy/languages/ko.yml
+++ b/themes/navy/languages/ko.yml
@@ -649,6 +649,7 @@ site:
       nimbus: 님버스
       keycard: 키카드
     connect: '소셜 미디어'
+    site-analytics: "웹 사이트 분석"
     privacy-policy:
       title: '개인정보 보호 정책'
       description: '스테이터스 연구 개발 GmbH, Baarerstrasse 10, Zug, Switzerland'

--- a/themes/navy/languages/ru.yml
+++ b/themes/navy/languages/ru.yml
@@ -649,6 +649,7 @@ site:
       nimbus: Nimbus
       keycard: Keycard
     connect: Подключиться
+    site-analytics: "Аналитика cайта"
     privacy-policy:
       title: 'Политика конфиденциальности'
       description: 'Status Research & Development GmbH, Baarerstrasse 10, Цуг, Швейцария.'

--- a/themes/navy/languages/zh.yml
+++ b/themes/navy/languages/zh.yml
@@ -649,6 +649,7 @@ site:
       nimbus: Nimbus
       keycard: Keycard
     connect: 联系我们
+    site-analytics: "Site Analytics"
     privacy-policy:
       title: 隐私政策
       description: 'Status Research＆Development GmbH，Baarerstrasse 10，Zug，Switzerland'

--- a/themes/navy/layout/layout.ejs
+++ b/themes/navy/layout/layout.ejs
@@ -21,13 +21,27 @@
     <script type="text/javascript" src="/js/main.js"></script>
 
     <script>
-      /* This POSTs to the clicks-api service to click numbers of downloads of different releases */
-      $(document).ready(function () {
-        $('a.app-download').click(function (ev) {
-          let downloadType = $(this).closest('a').attr('id')
-          $.post(`https://clicks.status.im/clicks/${downloadType}`)
+        /* This POSTs to the clicks-api service to click numbers of downloads of different releases */
+        $(document).ready(function () {
+          $('a.app-download').click(function (ev) {
+            let downloadType = $(this).closest('a').attr('id')
+            $.post(`https://clicks.status.im/clicks/${downloadType}`)
+          });
         });
-      });
+    </script>
+    <script>
+        /* Fathom - simple website analytics - https://github.com/usefathom/fathom */
+        (function(f, a, t, h, o, m){
+          a[h]=a[h]||function(){
+            (a[h].q=a[h].q||[]).push(arguments)
+          };
+          o=f.createElement('script'),
+          m=f.getElementsByTagName('script')[0];
+          o.async=1; o.src=t; o.id='fathom-script';
+          m.parentNode.insertBefore(o,m)
+        })(document, window, '//fathom.status.im/tracker.js', 'fathom');
+        fathom('set', 'siteId', '<%- config.fathom_site_id %>');
+        fathom('trackPageview');
     </script>
 </body>
 </html>

--- a/themes/navy/layout/partial/footer.ejs
+++ b/themes/navy/layout/partial/footer.ejs
@@ -152,6 +152,7 @@
                 <div class="col-md-12">
                     <div class="inline">
                         <a href="<%- show_lang() %>/privacy-policy/"><%- __('site.footer.privacy-policy.title') %></a>
+                        <a href="https://our.status.im/implementing-fathom-analytics-on-marketing-websites/"><%- __('site.footer.site-analytics') %></a>
                     </div>
                     <p><%- __('site.footer.privacy-policy.description') %></p>
                 </div>


### PR DESCRIPTION
Since I deployed Fathom Analytics as part of https://github.com/status-im/infra-misc/issues/21 we can add this JS script to start collecting basic data about visits to our website.

This also adds a footer link to the [article about Fathom Analytics on `our.status.im`](https://our.status.im/implementing-fathom-analytics-on-marketing-websites/).