### PR TITLE
Fix a link pointing to a wrong URL

### DIFF
--- a/themes/navy/layout/docs.ejs
+++ b/themes/navy/layout/docs.ejs
@@ -54,7 +54,7 @@
 							</div>
 							<div class="col-xl-4 col-md-6">
 								<div class="inner">
-									<a href="<%- show_lang() %>/security_docs/"><%- __('site.docs.categories.security.title') %></a>
+									<a href="<%- show_lang() %>/security/sec_matters.html"><%- __('site.docs.categories.security.title') %></a>
 									<span class="detail"><%- __('site.docs.categories.security.description') %></span>
 								</div>
 							</div>


### PR DESCRIPTION
A wrong URL returning a 404 error - https://status.im/docs/
<img width="273" alt="Screen Shot 2019-09-26 at 1 44 16 AM" src="https://user-images.githubusercontent.com/41753422/65621836-755a0880-dfff-11e9-96f6-223e5bffa802.png">

Fixed it and tested on my localhost as below

<img width="400" alt="Screen Shot 2019-09-26 at 1 46 54 AM" src="https://user-images.githubusercontent.com/41753422/65621896-902c7d00-dfff-11e9-9b6d-09f157cb043e.png">

@j-zerah let me know it