### PR TITLE
Improve the responsiveness of the Discord logos

### DIFF
--- a/themes/navy/layout/partial/footer.ejs
+++ b/themes/navy/layout/partial/footer.ejs
@@ -83,7 +83,7 @@
                         </li>
                         <li>
                             <a href="<%= config.discord_url %>" target="_blank">
-                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 245 245"> 
+                                <svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 245 245"> 
                                     <g opacity="0.5">
                                     <rect width="245" height="245" rx="20" fill="white" />
                                     <path fill-rule="evenodd" clip-rule="evenodd"


### PR DESCRIPTION
The Discord logo at the footer becomes too small on a small screen (smaller than 375 px) as below

<img width="507" alt="Screen Shot 2019-12-06 at 9 52 57 PM" src="https://user-images.githubusercontent.com/41753422/70324434-ce051780-1872-11ea-99aa-3b46883b9055.png">

=> Set a width and height of the logo and works well in a small screen
<img width="461" alt="Screen Shot 2019-12-06 at 9 54 46 PM" src="https://user-images.githubusercontent.com/41753422/70324563-2c31fa80-1873-11ea-9de1-136b365e7903.png">
 
Tested locally

