### PR TITLE
update docs with Nix changes from status-react#9605

### DIFF
--- a/source/build_status/desktop.md
+++ b/source/build_status/desktop.md
@@ -21,7 +21,7 @@ Note: for a Windows build cross-compiled from Linux, replace `make release-deskt
 
 ## To install react-native-cli with desktop commands support
 
-Remove the `export PATH="$STATUS_REACT_HOME/node_modules/.bin:$PATH"` line in https://github.com/status-im/status-react/blob/develop/nix/derivation.nix and run:
+Remove the `export PATH="$STATUS_REACT_HOME/node_modules/.bin:$PATH"` line in https://github.com/status-im/status-react/blob/develop/nix/tools/mkShell.nix and run:
 
 ``` bash
 git clone https://github.com/status-im/react-native-desktop.git

--- a/source/build_status/first_pr_guide.md
+++ b/source/build_status/first_pr_guide.md
@@ -40,7 +40,7 @@ git checkout -b my_example_status_branch -t upstream/develop
 Depending on which environment you want to build for (Android/iOS/Desktop), there are different build targets to leverage.  Update the target OS defined below based on your intended build environment.
 
 ```bash
-make shell TARGET_OS=android
+make shell TARGET=android
 ```
 
 Follow the more detailed walkthroughs in the below links to get up and running with the end-to-end build process for each environment.

--- a/source/build_status/index.md
+++ b/source/build_status/index.md
@@ -31,9 +31,9 @@ If you're on NixOS, please run the following to ensure you have the necessary pr
 nix-env --install git gnumake
 ```
 
-In order to work with status-react, you need to be inside a Nix shell. The makefile targets will ensure you are in a Nix shell, or start one for you implicitly. However, if you're going to be running multiple commands on the same terminal, you might want to start a dedicated Nix shell by running `make shell TARGET_OS=android` (or using other `TARGET_OS`).
+In order to work with status-react, you need to be inside a Nix shell. The makefile targets will ensure you are in a Nix shell, or start one for you implicitly. However, if you're going to be running multiple commands on the same terminal, you might want to start a dedicated Nix shell by running `make shell TARGET=android` (or using other `TARGET`).
 
-The `make shell TARGET_OS=<os>` script prepares and installs the following:
+The `make shell TARGET=<os>` script prepares and installs the following:
 
 - Java 8
 - Clojure and Leiningen
@@ -53,11 +53,9 @@ The `make shell TARGET_OS=<os>` script prepares and installs the following:
 
 *Note 1:* It can take up to 60 minutes depending on your machine and internet connection speed.
 
-*Note 2:* Specific tool versions used are maintained in the [.TOOLVERSIONS](https://github.com/status-im/status-react/blob/develop/.TOOLVERSIONS) file.
+*Note 2:* An environment variable called `TARGET` controls the type of shell that is started. If you want to limit the amount of dependencies downloaded, you could run `make shell TARGET=android`. Most of the makefile targets already include a sensible default.
 
-*Note 3:* An environment variable called `TARGET_OS` controls the type of shell that is started. If you want to limit the amount of dependencies downloaded, you could run `make shell TARGET_OS=android`. Most of the makefile targets already include a sensible default.
-
-*Note 4:* On macOS, the build environment is set up to rely on XCode 11.1. If you want to use an unsupported version, you'll need to edit the version in [nix/mobile/default.nix](https://github.com/status-im/status-react/blob/develop/nix/mobile/default.nix) file (`xcodewrapperArgs.version`).
+*Note 3:* On macOS, the build environment is set up to rely on XCode 11.1. If you want to use an unsupported version, you'll need to edit the version in [nix/mobile/default.nix](https://github.com/status-im/status-react/blob/develop/nix/mobile/default.nix) file (`xcodewrapperArgs.version`).
 
 ## Running development processes
 
@@ -116,9 +114,9 @@ Installation script installs Android SDK and Android NDK.
 
 Once Android SDK is set up, execute:
 
-  ```bash
-  make run-android
-  ```
+```bash
+make run-android
+```
 
 Check the following docs if you still have problems:
 
@@ -132,9 +130,8 @@ Check the following docs if you still have problems:
 
 If you need to use a branch of a status-go fork as a dependency of status-react, you can have the scripts build it.
 
-1. Make sure you are in the root of the `status-react` repo and start a Nix shell using `make shell TARGET_OS=android`.
+1. Make sure you are in the root of the `status-react` repo and start a Nix shell using `make shell TARGET=android`.
 1. Run `scripts/update-status-go.sh <rev>`, where `rev` is a branch name, tag, or commit SHA1 you want to build.
-1. Exit the shell in order to make sure Nix notices the version change.
 
 The script will save the indicated commit hash along with other information in the `status-go-version.json` file.
 
@@ -174,17 +171,21 @@ Assuming re-frisk is running in port 4567, you can just navigate to http://local
 
 ## Updating dependencies
 
-### Desktop node dependencies
+### iOS CocoaPods dependencies
 
-Whenever the `desktop_files/yarn.lock` file changes, `make update-npm-nix` should be run in order to update the [`node2nix`](https://github.com/svanderburg/node2nix) files at `nix/desktop/realm-node/output`.
+Whenever the iOS NodeJS dependencies change, `make nix-update-pods` should be run in order to update `ios/Podfile` and `ios/Podfile.loc`.
 
 ### Android Gradle Maven dependencies
 
-Whenever the Android project changes in terms of Gradle dependencies, `make update-gradle-nix` should be run in order to update `nix/mobile/android/maven-and-npm-deps/maven/maven-sources.nix`.
+Whenever the Android project changes in terms of Gradle dependencies, `make nix-update-gradle` should be run in order to update `nix/mobile/android/maven-and-npm-deps/maven/maven-sources.nix`.
 
 ### Leiningen Maven dependencies
 
-Whenever the Leiningen dependencies change, `make update-lein-nix` should be run in order to update `nix/lein/lein-project-deps.nix`.
+Whenever the Leiningen dependencies change, `make nix-update-lein` should be run in order to update `nix/lein/lein-project-deps.nix`.
+
+### Fastlane Ruby dependencies
+
+Whenever Fastlane and its modules need updating, `make nix-update-gems` should be run in order to update `fastlane/Gemfile.lock` and `fastlane/gemset.nix`.
 
 ## Troubleshooting
 

--- a/source/build_status/makefile_tour.md
+++ b/source/build_status/makefile_tour.md
@@ -11,7 +11,7 @@ Below are some of the more useful Makefile targets that will help you with the d
 
 # Development Shell
 
-`make shell` is the most fundamental target in the Makefile.  At its core, it will either build or launch a [Nix](https://github.com/status-im/status-react/tree/develop/nix) shell preconfigured to build Status.  If this is your first time building status, this is where you'll start.  Run `make shell TARGET_OS={os_name}` where `os_name` is `android`/`ios`/`linux`/`macos`/`windows` and the Makefile will build out the Nix environment and get you ready to start coding.  Now, go get a cup of coffee.  It'll take a while to finish this process.
+`make shell` is the most fundamental target in the Makefile.  At its core, it will either build or launch a [Nix](https://github.com/status-im/status-react/tree/develop/nix) shell preconfigured to build Status.  If this is your first time building status, this is where you'll start.  Run `make shell TARGET={os_name}` where `os_name` is `android`/`ios`/`linux`/`macos`/`windows` and the Makefile will build out the Nix environment and get you ready to start coding.  Now, go get a cup of coffee.  It'll take a while to finish this process.
 
 Valid target OS options are available in the [`nix/platforms.nix`](https://github.com/status-im/status-react/blob/develop/nix/platform.nix) file.
 
@@ -26,12 +26,12 @@ You will need to run one of each target in separate terminals from the following
 
 `make startdev-**` is the set of targets that starts up Figwheel and the Clojurescript REPL.  Depending on what environment you're coding on, you'll use one of the following targets.
 
-* `make startdev-android-real` - when using a real Android device for development
-* `make startdev-android-avd` - when using a virtual Android device for development
-* `make startdev-android-genymotion` - when using the Genymotion simulator for Android development
-* `make startdev-ios-real` - when using a real iOS device for development
-* `make startdev-ios-simulator` - when using the XCode IOS simulator for development
-* `make startdev-desktop` - when developing for Status Desktop
+* `make startdev-android-real` - For using a real Android device for development
+* `make startdev-android-avd` - For using a virtual Android device for development
+* `make startdev-android-genymotion` - For using the Genymotion simulator for Android development
+* `make startdev-ios-real` - For using a real iOS device for development
+* `make startdev-ios-simulator` - For using the XCode IOS simulator for development
+* `make startdev-desktop` - For developing for Status Desktop
 
 Note: If developing with a real Android device, make sure to also run `make android-ports` or the REPL won't connect to your device.
 
@@ -60,10 +60,10 @@ OS targets
 `make release` builds a release version of the app that is ready for install on Android and iOS.
 
 OS targets
-* `make release-android` Builds the Android version of the app
-* `make release-ios` Builds the iOS version of the app
-* `make release-desktop` Builds a desktop version of the app
-*  `make release-windows-desktop` Builds a Windows desktop version of the app (available on Linux hosts)
+* `make release-android` - Builds the Android version of the app
+* `make release-ios` - Builds the iOS version of the app
+* `make release-desktop` - Builds a desktop version of the app
+* `make release-windows-desktop` - Builds a Windows desktop version of the app (available on Linux hosts)
 
 # Additional Targets
 
@@ -71,26 +71,21 @@ OS targets
 
 There are three targets related to testing.
 
-`make test` will run all the NodeJS unit tests once and print the output to the screen.
-
-`make test-auto` will run all the NodeJS unit tests in interactive mode, monitoring the code base for any changes and then re-running the test suite when changes are detected.
-
-`make coverage` will run the NodeJS unit tests once and generate a coverage report.
-
-`make lint` will run the linter and fix any formatting issues.
+* `make test` - Runs all the NodeJS unit tests once and print the output to the screen.
+* `make test-auto` - Runs all the NodeJS unit tests in interactive mode, monitoring the code base for any changes and then re-running the test suite when changes are detected.
+* `make coverage` - Runs the NodeJS unit tests once and generate a coverage report.
+* `make lint` - Runs the linter and fix any formatting issues.
 
 ## Android Targets
 
-`make android-ports` will set up the ADB proxy ports to make sure the REPL/development server can connect to the device/simulator.
-
-`make android-logcat` Run this in a separate terminal and it will continuously print the logs from ADB that are specific to the Status app
-
-`make android-clean` will clean up the android development environment, causing Gradle to rebuild the entire app the next time you run `make run-android`
+* `make android-ports` - Sets up the ADB proxy ports to make sure the REPL/development server can connect to the device/simulator.
+* `make android-logcat` - Run this in a separate terminal and it will continuously print the logs from ADB that are specific to the Status app
+* `make android-clean` - Cleans up the android development environment, causing Gradle to rebuild the entire app the next time you run `make run-android`
 
 ## Nix Targets
 
 Note: These targets will not work on [MacOS Catalina](https://github.com/status-im/status-react/tree/develop/nix#macos-1015-catalina).
 
-`make nix-purge` Sometimes, your dev environment gets hosed and you just need to start over.  This target will completely purge the entire Nix build environment.  If you run this command, you will need to run `make shell TARGET_OS={preferred OS}` before you can continue developing.
-
-`make nix-clean` purges out all the Status build artifacts.  This isn't as extreme as `make nix-purge` but will still give you a fresh start on building the app if something goes awry in your dev environment.
+* `make nix-purge` - Sometimes, your dev environment gets hosed and you just need to start over.  This target will completely purge the entire Nix build environment.  If you run this command, you will need to run `make shell TARGET={preferred OS}` before you can continue developing.
+* `make nix-clean` - Cleans up all the Status build artifacts.  This isn't as extreme as `make nix-purge` but will still give you a fresh start on building the app if something goes awry in your dev environment.
+* `make nix-gc` - Removes from the Nix store all packages older than 20 days. Great way to recover some lost disk space.

--- a/source/build_status/status_react_quickstart.md
+++ b/source/build_status/status_react_quickstart.md
@@ -40,13 +40,13 @@ Building out your own dev version of Status is the best way to experiment before
 
 Open up three terminal windows (or tabs), and ensure you keep all three open.  In the first, enter the command:
 
-``` bash
+```bash
 make startdev-ios-simulator
 ```
 
 Under the hood, this command runs the equivalent of:
 
-``` bash
+```bash
 clj -R:dev build.clj watch --platform ios --ios-device simulator
 ```
 
@@ -56,7 +56,7 @@ With that entered, you should see the following, after a short time:
 
 With Figwheel started, re-frisk started, and the ClojureScript REPL started, you can move onto the second window, and enter the next command:
 
-``` bash
+```bash
 make react-native-ios
 ```
 
@@ -66,7 +66,7 @@ By executing this make script, a Nix environment will be created for iOS, runnin
 
 The image above reflects how the terminal window will remain, until the third command has been successfully executed.  Head into the third Terminal window, and enter: 
  
-``` bash
+```bash
 make run-ios
 ```
 
@@ -100,8 +100,11 @@ As mentioned above, our Makefiles loaded up a re-frisk instance for us, to aid d
 
 If for any reason you need to completely clean up Status, go to `~/Library/Application Support/` and delete any `Status` directories. Delete the app in `/Application`. Then you are ready to reinstall.
 
-You can also purge / clean up Nix by running the command:
-
-``` bash
+To free up space by removing old packages from the Nix store you can use:
+```bash
+make nix-gc
+```
+You can also purge Nix and all its related files by running the command:
+```bash
 make nix-purge
 ```


### PR DESCRIPTION
Mostly renames `TARGET_OS` to `TARGET` and adds info about `make nix-gc` for space cleanup.
Also some small formatting fixes.