### PR TITLE
fix build process by removing bundle loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "clean": "rm -rf public/*",
-    "build": "gulp run",
+    "build": "gulp build",
     "index": "gulp index",
     "eslint": "eslint .",
     "deploy": "hexo deploy",
@@ -17,7 +17,6 @@
     "babel-core": "^6.26.0",
     "babelify": "^8.0.0",
     "browser-sync": "^2.26.7",
-    "browserify": "^16.2.0",
     "cheerio": "^0.20.0",
     "d3": "^5.1.0",
     "d3-ease": "^1.0.2",

--- a/themes/navy/layout/layout.ejs
+++ b/themes/navy/layout/layout.ejs
@@ -18,7 +18,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/sticky-kit/1.1.3/sticky-kit.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/masonry/4.2.2/masonry.pkgd.min.js"></script>
     <script src="https://unpkg.com/imagesloaded@4/imagesloaded.pkgd.min.js"></script>
-    <script type="text/javascript" src="/js/main.js"></script>
+    <script type="text/javascript" src="/js/main.min.js"></script>
 
     <script>
         /* This POSTs to the clicks-api service to click numbers of downloads of different releases */

--- a/themes/navy/source/js/main.js
+++ b/themes/navy/source/js/main.js
@@ -1,475 +1,422 @@
-(function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
-(function () {
-  function r(e, n, t) {
-    function o(i, f) {
-      if (!n[i]) {
-        if (!e[i]) {
-          var c = "function" == typeof require && require;if (!f && c) return c(i, !0);if (u) return u(i, !0);var a = new Error("Cannot find module '" + i + "'");throw a.code = "MODULE_NOT_FOUND", a;
-        }var p = n[i] = { exports: {} };e[i][0].call(p.exports, function (r) {
-          var n = e[i][1][r];return o(n || r);
-        }, p, p.exports, r, e, n, t);
-      }return n[i].exports;
-    }for (var u = "function" == typeof require && require, i = 0; i < t.length; i++) o(t[i]);return o;
-  }return r;
-})()({ 1: [function (require, module, exports) {
-    (function () {
-      function r(e, n, t) {
-        function o(i, f) {
-          if (!n[i]) {
-            if (!e[i]) {
-              var c = "function" == typeof require && require;if (!f && c) return c(i, !0);if (u) return u(i, !0);var a = new Error("Cannot find module '" + i + "'");throw a.code = "MODULE_NOT_FOUND", a;
-            }var p = n[i] = { exports: {} };e[i][0].call(p.exports, function (r) {
-              var n = e[i][1][r];return o(n || r);
-            }, p, p.exports, r, e, n, t);
-          }return n[i].exports;
-        }for (var u = "function" == typeof require && require, i = 0; i < t.length; i++) o(t[i]);return o;
-      }return r;
-    })()({ 1: [function (require, module, exports) {
-        (function () {
-          function r(e, n, t) {
-            function o(i, f) {
-              if (!n[i]) {
-                if (!e[i]) {
-                  var c = "function" == typeof require && require;if (!f && c) return c(i, !0);if (u) return u(i, !0);var a = new Error("Cannot find module '" + i + "'");throw a.code = "MODULE_NOT_FOUND", a;
-                }var p = n[i] = { exports: {} };e[i][0].call(p.exports, function (r) {
-                  var n = e[i][1][r];return o(n || r);
-                }, p, p.exports, r, e, n, t);
-              }return n[i].exports;
-            }for (var u = "function" == typeof require && require, i = 0; i < t.length; i++) o(t[i]);return o;
-          }return r;
-        })()({ 1: [function (require, module, exports) {
-            (function () {
-              function r(e, n, t) {
-                function o(i, f) {
-                  if (!n[i]) {
-                    if (!e[i]) {
-                      var c = "function" == typeof require && require;if (!f && c) return c(i, !0);if (u) return u(i, !0);var a = new Error("Cannot find module '" + i + "'");throw a.code = "MODULE_NOT_FOUND", a;
-                    }var p = n[i] = { exports: {} };e[i][0].call(p.exports, function (r) {
-                      var n = e[i][1][r];return o(n || r);
-                    }, p, p.exports, r, e, n, t);
-                  }return n[i].exports;
-                }for (var u = "function" == typeof require && require, i = 0; i < t.length; i++) o(t[i]);return o;
-              }return r;
-            })()({ 1: [function (require, module, exports) {
-                (function () {
-                  function r(e, n, t) {
-                    function o(i, f) {
-                      if (!n[i]) {
-                        if (!e[i]) {
-                          var c = "function" == typeof require && require;if (!f && c) return c(i, !0);if (u) return u(i, !0);var a = new Error("Cannot find module '" + i + "'");throw a.code = "MODULE_NOT_FOUND", a;
-                        }var p = n[i] = { exports: {} };e[i][0].call(p.exports, function (r) {
-                          var n = e[i][1][r];return o(n || r);
-                        }, p, p.exports, r, e, n, t);
-                      }return n[i].exports;
-                    }for (var u = "function" == typeof require && require, i = 0; i < t.length; i++) o(t[i]);return o;
-                  }return r;
-                })()({ 1: [function (require, module, exports) {
-                    (function () {
-                      function r(e, n, t) {
-                        function o(i, f) {
-                          if (!n[i]) {
-                            if (!e[i]) {
-                              var c = "function" == typeof require && require;if (!f && c) return c(i, !0);if (u) return u(i, !0);var a = new Error("Cannot find module '" + i + "'");throw a.code = "MODULE_NOT_FOUND", a;
-                            }var p = n[i] = { exports: {} };e[i][0].call(p.exports, function (r) {
-                              var n = e[i][1][r];return o(n || r);
-                            }, p, p.exports, r, e, n, t);
-                          }return n[i].exports;
-                        }for (var u = "function" == typeof require && require, i = 0; i < t.length; i++) o(t[i]);return o;
-                      }return r;
-                    })()({ 1: [function (require, module, exports) {
-                        $(document).ready(function ($) {
+$(document).ready(function($) {
 
-                          var w = Math.max(document.documentElement.clientWidth, window.innerWidth || 0),
-                              h = Math.max(document.documentElement.clientHeight, window.innerHeight || 0),
-                              $msnry;
+  var w = Math.max(document.documentElement.clientWidth, window.innerWidth || 0),
+    h = Math.max(document.documentElement.clientHeight, window.innerHeight || 0),
+    $msnry;
 
-                          mobileMenu(w);
-                          mobileFooterMenu(w);
+  mobileMenu(w);
+  mobileFooterMenu(w);
 
-                          $(window).on('resize', function (event) {
-                            w = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
-                            mobileMenu(w);
-                            mobileFooterMenu(w);
+  $(window).on('resize', function(event) {
+    w = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
+    mobileMenu(w);
+    mobileFooterMenu(w);
 
-                            if ($('.using-snt').length) {
-                              if (w > 767) {
-                                if ($msnry == null) {
-                                  $msnry = $('.items').masonry({
-                                    itemSelector: '.item'
-                                  });
-                                  $msnry.masonry('layout');
-                                }
-                              } else {
-                                if ($msnry != null) {
-                                  $msnry.masonry('destroy');
-                                  $msnry = null;
-                                }
-                              }
-                            }
-                          });
+    if($('.using-snt').length){
+      if(w > 767){
+        if($msnry == null){
+          $msnry = $('.items').masonry({
+            itemSelector: '.item'
+          });
+          $msnry.masonry('layout');
+        }
+      }else{
+        if($msnry != null){
+          $msnry.masonry('destroy');
+          $msnry = null;
+        }
+      }
+    }
 
-                          $('.language-selector-trigger').on('click', function (event) {
-                            event.preventDefault();
-                            $('.language-selector').toggleClass('active');
-                          });
+  });
 
-                          $('.using-snt').imagesLoaded(function () {
-                            if (w > 767) {
-                              $msnry = $('.items').masonry({
-                                itemSelector: '.item'
-                              });
-                              $msnry.masonry('layout');
-                            }
-                          });
+  $('.language-selector-trigger').on('click', function (event) {
+    event.preventDefault();
+    $('.language-selector').toggleClass('active');
+  });
 
-                          $('.about-mission .inner .inline-links a, .snt-intro .inline-links a, .snt-basics a[href="#using-snt"], .snt-basics a[href="#research"]').on('click', function () {
-                            var id = $(this).attr('href');
-                            $('html, body').animate({
-                              scrollTop: $(id).offset().top + 5
-                            }, 500);
-                            return false;
-                          });
+  $('.using-snt').imagesLoaded( function() {
+    if(w > 767){
+      $msnry = $('.items').masonry({
+        itemSelector: '.item'
+      });
+      $msnry.masonry('layout');
+    }
+  });
 
-                          // box-remember styling wrapper (part of the b9lab documentation update)
-                          $(".box-remember").wrap("<div class='box-remember-wrapper'></div>");
-                          $(".box-remember").before("<div class='before-box-remember'><img src='/img/box-remember.svg')'></div>");
+  $('.about-mission .inner .inline-links a, .snt-intro .inline-links a, .snt-basics a[href="#using-snt"], .snt-basics a[href="#research"]').on('click', function() {
+    var id = $(this).attr('href');
+    $('html, body').animate({
+      scrollTop: $(id).offset().top + 5
+    }, 500);
+    return false;
+  });
 
-                          function mobileMenu(w) {
-                            if (w < 1199) {
-                              $('header nav, header .btns').appendTo('.mobile-nav');
-                            } else {
-                              $('.mobile-nav nav, .mobile-nav .btns').insertBefore('.mobile-nav-trigger');
-                            }
-                          }
+  // box-remember styling wrapper (part of the b9lab documentation update)
+  $(".box-remember").wrap("<div class='box-remember-wrapper'></div>");
+  $(".box-remember").before("<div class='before-box-remember'><img src='/img/box-remember.svg')'></div>");
 
-                          function mobileFooterMenu(w) {
-                            if (w < 768) {
-                              $('footer .navigation h5 a').attr('aria-expanded', 'false').addClass('collapsed');
-                              $('footer .collapse').removeClass('show');
-                            } else {
-                              $('footer .navigation h5 a').attr('aria-expanded', 'true').removeClass('collapsed');
-                              $('footer .collapse').addClass('show');
-                            }
-                          }
 
-                          $('.mobile-nav-trigger-close, .mobile-nav-trigger, .backdrop').on('click', function (event) {
-                            event.preventDefault();
-                            $('body').toggleClass('nav-active');
-                          });
+  function mobileMenu(w) {
+    if (w < 1199) {
+      $('header nav, header .btns').appendTo('.mobile-nav');
+    } else {
+      $('.mobile-nav nav, .mobile-nav .btns').insertBefore('.mobile-nav-trigger');
+    }
+  }
 
-                          $('.community-nav-trigger-close, .community-nav-trigger, .backdrop-community-nav').on('click', function (event) {
-                            event.preventDefault();
-                            $('body').toggleClass('community-nav-active');
-                          });
+  function mobileFooterMenu(w) {
+    if (w < 768) {
+      $('footer .navigation h5 a').attr('aria-expanded', 'false').addClass('collapsed');
+      $('footer .collapse').removeClass('show');
+    } else {
+      $('footer .navigation h5 a').attr('aria-expanded', 'true').removeClass('collapsed');
+      $('footer .collapse').addClass('show');
+    }
+  }
 
-                          try {
-                            highlight();
-                          } catch (err) {
-                            setTimeout(function () {
-                              highlight();
-                            }, 2500);
-                          }
+  $('.mobile-nav-trigger-close, .mobile-nav-trigger, .backdrop').on('click', function(event) {
+    event.preventDefault();
+    $('body').toggleClass('nav-active');
+  });
 
-                          function highlight() {
-                            $('.editor-content pre code').each(function (i, block) {
-                              hljs.highlightBlock(block);
-                            });
-                          }
+  $('.community-nav-trigger-close, .community-nav-trigger, .backdrop-community-nav').on('click', function(event) {
+    event.preventDefault();
+    $('body').toggleClass('community-nav-active');
+  });
 
-                          if ($('.recently-updated').length) {
+  try {
+    highlight();
+  } catch (err) {
+    setTimeout(function() {
+      highlight();
+    }, 2500);
+  }
 
-                            var html = '';
+  function highlight() {
+    $('.editor-content pre code').each(function(i, block) {
+      hljs.highlightBlock(block);
+    });
+  }
 
-                            if (typeof Cookies.get('recently-updated') !== 'undefined') {
-                              $('.recently-updated').append(Cookies.get('recently-updated'));
-                            } else {
-                              fetch('https://api.github.com/users/status-im/repos?sort=updated&per_page=3').then(function (response) {
-                                if (response.status !== 200) {
-                                  console.log('Looks like there was a problem. Status Code: ' + response.status);
-                                  return;
-                                }
+  if ($('.recently-updated').length) {
 
-                                response.json().then(function (data) {
+    var html = '';
 
-                                  data.forEach(function (element) {
-                                    html += '<li><a href="' + element.html_url + '">' + element.full_name + '</a></li>';
-                                  });
+    if (typeof Cookies.get('recently-updated') !== 'undefined') {
+      $('.recently-updated').append(Cookies.get('recently-updated'));
+    } else {
+      fetch('https://api.github.com/users/status-im/repos?sort=updated&per_page=3')
+        .then(
+          function(response) {
+            if (response.status !== 200) {
+              console.log('Looks like there was a problem. Status Code: '
+              + response.status);
+              return;
+            }
 
-                                  Cookies.set('recently-updated', html, { expires: 1 });
-                                  $('.recently-updated').append(html);
-                                });
-                              }).catch(function (err) {
-                                console.log('Fetch Error :-S', err);
-                              });
-                            }
-                          }
+            response.json().then(function(data) {
 
-                          if ($('#advocacy-programs').length) {
-                            function retrieveAdvocacyPrograms() {
-                              $.ajax({
-                                type: 'get',
-                                url: 'https://statusphere.status.im/api/v1/boards/public/?is_featured=true&org=375',
-                                success: function (response) {
-                                  $.each(response, function (index, program) {
-                                    var description = program.description.substr(0, 200) + '...';
-                                    $('#advocacy-programs').prepend('<div class="inner"> \
-                <a href="https://statusphere.status.im/b/' + program.uuid + '/view" class="card-inner"> \
-                  ' + program.title + '\
+              data.forEach(function(element) {
+                html += '<li><a href="' + element.html_url + '">' + element.full_name + '</a></li>';
+              });
+
+              Cookies.set('recently-updated', html, { expires: 1 });
+              $('.recently-updated').append(html);
+
+            });
+
+          }
+        )
+        .catch(function(err) {
+          console.log('Fetch Error :-S', err);
+        });
+    }
+
+  }
+
+  if ($('#advocacy-programs').length) {
+    function retrieveAdvocacyPrograms() {
+      $.ajax({
+        type: 'get',
+        url: 'https://statusphere.status.im/api/v1/boards/public/?is_featured=true&org=375',
+        success: function(response) {
+          $.each(response, function(index, program) {
+            var description = program.description.substr(0, 200) + '...';
+            $('#advocacy-programs').prepend('<div class="inner"> \
+                <a href="https://statusphere.status.im/b/'+ program.uuid+'/view" class="card-inner"> \
+                  '+program.title+'\
                 </a> \
-                <p class="details">' + description + '</p> \
+                <p class="details">'+description+'</p> \
               </div>');
-                                  });
-                                }
-                              });
-                            }
+          });
+        }
+      });
+    }
 
-                            retrieveAdvocacyPrograms();
-                          }
+    retrieveAdvocacyPrograms();
 
-                          $('.sidebar').stick_in_parent({
-                            offset_top: 30
-                          });
+  }
 
-                          if ($('input[name="userSearch"]').length) {
-                            let domain = window.location.hostname;
-                            if (domain == 'localhost') {
-                              domain = 'dev.status.im';
-                            }
-                            window.addEventListener('click', function (e) {
-                              if (document.getElementById('search-form').contains(e.target)) {
-                                $('#search-form').removeClass('inactive');
-                              } else {
-                                $('#search-form').addClass('inactive');
-                              }
-                            });
-                            $('input[name="userSearch"]').on('keyup', function () {
-                              var val = $(this).val();
-                              $('#search-results').empty();
-                              $.ajax({
-                                url: `https://search.status.im/${domain}/_search?size=10&_source=title,url&&q=${val}`
-                              }).done(function (results) {
-                                $.each(results.hits.hits, function (index, value) {
-                                  $(`<a href="${value._source.url}">${value._source.title}</a>`).appendTo('#search-results');
-                                });
-                              });
-                            });
-                          }
+  $('.sidebar').stick_in_parent({
+    offset_top: 30
+  });
 
-                          $('.features-intro ul li a').on('click', function (event) {
-                            event.preventDefault();
-                            var id = $(this).attr('href');
-                            $('html, body').animate({
-                              scrollTop: $(id).offset().top
-                            }, 300);
-                          });
+  if ($('input[name="userSearch"]').length) {
+    window.addEventListener('click', function(e) {
+      if (document.getElementById('search-form').contains(e.target)) {
+        $('#search-form').removeClass('inactive');
+      } else {
+        $('#search-form').addClass('inactive');
+      }
+    });
+    $('input[name="userSearch"]').on('keyup', function() {
+      var val = $(this).val();
+      $('#search-results').empty();
+      $.ajax({
+        url: 'https://search.status.im/status.im/_search?size=10&_source=title,url&&q=' + val
+      })
+        .done(function(results) {
+          $.each(results.hits.hits, function(index, value) {
+            $('<a href="' + value._source.url + '">' + value._source.title + '</a>').appendTo('#search-results');
+          });
+        });
+    });
+  }
 
-                          if ($('.home-intro .announcement').length) {
-                            var ghostContentKey = '10e7f8c1f793d2945ea1177076';
-                            $.ajax({
-                              url: 'https://our.status.im/ghost/api/v2/content/posts/?key=' + ghostContentKey + '&limit=1&fields=title,url'
-                            }).done(function (results) {
-                              $('.home-intro .announcement b').text(results.posts[0].title);
-                              $('.home-intro .announcement').attr('href', results.posts[0].url).removeClass('inactive');
-                            }).fail(function () {
-                              $.ajax({
-                                url: 'https://our.status.im/ghost/api/v0.1/posts/?include=tags&formats=plaintext&client_id=ghost-frontend&client_secret=2b055fcd57ba&limit=1'
-                              }).done(function (results) {
-                                $('.home-intro .announcement b').text(results.posts[0].title);
-                                $('.home-intro .announcement').attr('href', 'https://our.status.im' + results.posts[0].url).removeClass('inactive');
-                              });
-                            });
-                          }
+  $('.features-intro ul li a').on('click', function(event) {
+    event.preventDefault();
+    var id = $(this).attr('href');
+    $('html, body').animate({
+      scrollTop: $(id).offset().top
+    }, 300);
+  });
 
-                          $('.sidebar-mobile-trigger, .mobile-sidebar-trigger-close').on('click', function (event) {
-                            event.preventDefault();
-                            $('body').toggleClass('sidebar-active');
-                          });
+  if ($('.home-intro .announcement').length) {
+    var ghostContentKey = '10e7f8c1f793d2945ea1177076';
+    $.ajax({
+      url: 'https://our.status.im/ghost/api/v2/content/posts/?key='+ ghostContentKey +'&limit=1&fields=title,url'
+    })
+    .done(function(results) {
+      $('.home-intro .announcement b').text(results.posts[0].title);
+      $('.home-intro .announcement').attr('href', results.posts[0].url).removeClass('inactive');
+    })
+    .fail(function() {
+      $.ajax({
+        url: 'https://our.status.im/ghost/api/v0.1/posts/?include=tags&formats=plaintext&client_id=ghost-frontend&client_secret=2b055fcd57ba&limit=1'
+      })
+      .done(function(results) {
+        $('.home-intro .announcement b').text(results.posts[0].title);
+        $('.home-intro .announcement').attr('href', 'https://our.status.im' + results.posts[0].url).removeClass('inactive');
+      });
+    })
+  }
 
-                          if ($('.quick-nav').length) {
-                            var quickNavOffset = $('.quick-nav').offset().top;
-                            $(window).on('resize', function () {
-                              quickNavOffset = $('.quick-nav').offset().top;
-                            });
-                            $(window).on('scroll', function () {
-                              var y = $(window).scrollTop();
-                              if (y > quickNavOffset) {
-                                $('.quick-nav, .quick-nav-sub').addClass('fixed');
-                              } else {
-                                $('.quick-nav, .quick-nav-sub').removeClass('fixed');
-                              }
-                            });
-                            $('.quick-nav-sub ul li a').on('click', function (event) {
-                              event.preventDefault();
-                              var id = $(this).attr('href');
-                              $('html, body').animate({
-                                scrollTop: $(id).offset().top - 100
-                              }, 300);
-                            });
-                          }
+  $('.sidebar-mobile-trigger, .mobile-sidebar-trigger-close').on('click', function(event) {
+    event.preventDefault();
+    $('body').toggleClass('sidebar-active');
+  });
 
-                          if ($('.open-issues').length) {
+  if ($('.quick-nav').length) {
+    var quickNavOffset = $('.quick-nav').offset().top;
+    $(window).on('resize', function () {
+      quickNavOffset = $('.quick-nav').offset().top;
+    });
+    $(window).on('scroll', function () {
+      var y = $(window).scrollTop();
+      if (y > quickNavOffset) {
+        $('.quick-nav, .quick-nav-sub').addClass('fixed');
+      } else {
+        $('.quick-nav, .quick-nav-sub').removeClass('fixed');
+      }
+    });
+    $('.quick-nav-sub ul li a').on('click', function(event) {
+      event.preventDefault();
+      var id = $(this).attr('href');
+      $('html, body').animate({
+        scrollTop: $(id).offset().top - 100
+      }, 300);
+    });
+  }
 
-                            var htmlReact = '';
+  if ($('.open-issues').length) {
 
-                            if (typeof Cookies.get('open-issues-react') !== 'undefined') {
-                              $('.open-issues-react').append(localStorage.getItem('open-issues-react'));
-                            } else {
-                              fetch('https://api.github.com/repos/status-im/status-react/issues?sort=created&per_page=30').then(function (response) {
-                                if (response.status !== 200) {
-                                  console.log('Looks like there was a problem. Status Code: ' + response.status);
-                                  return;
-                                }
+    var htmlReact = '';
 
-                                response.json().then(function (data) {
+    if (typeof Cookies.get('open-issues-react') !== 'undefined') {
+      $('.open-issues-react').append(localStorage.getItem('open-issues-react'));
+    } else {
+      fetch('https://api.github.com/repos/status-im/status-react/issues?sort=created&per_page=30')
+        .then(
+          function(response) {
+            if (response.status !== 200) {
+              console.log('Looks like there was a problem. Status Code: ' + response.status);
+              return;
+            }
 
-                                  var i = 0;
+            response.json().then(function(data) {
 
-                                  data.forEach(function (element) {
-                                    if (typeof element.pull_request === 'undefined') {
-                                      if (i < 4) {
-                                        var current = new Date();
-                                        var labelsHtml = '<div class="tags">';
-                                        var labels = element.labels;
-                                        labels.forEach(function (label) {
-                                          labelsHtml += '<div class="tag">' + label.name + '</div>';
-                                        });
-                                        labelsHtml += '</div>';
-                                        htmlReact += '<li> \
-                        <div class="number">#' + element.number + '</div> \
+              var i = 0;
+
+              data.forEach(function(element) {
+                if (typeof element.pull_request === 'undefined') {
+                  if(i < 4){
+                    var current= new Date();
+                    var labelsHtml = '<div class="tags">';
+                    var labels = element.labels;
+                    labels.forEach(function(label){
+                      labelsHtml += '<div class="tag">'+ label.name +'</div>'
+                    });
+                    labelsHtml += '</div>';
+                    htmlReact += '<li> \
+                        <div class="number">#'+ element.number +'</div> \
                         <div class="details"> \
-                          <b><a href="' + element.html_url + '" target="_blank">' + element.title + '</a></b> \
-                            ' + labelsHtml + ' \
+                          <b><a href="'+ element.html_url +'" target="_blank">' + element.title + '</a></b> \
+                            '+ labelsHtml +' \
                           <div class="opened"> \
-                            Opened: <time>' + timeDifference(current, new Date(element.created_at)) + '</time> \
+                            Opened: <time>'+ timeDifference(current, new Date(element.created_at)) +'</time> \
                           </div> \
                           <div class="activity"> \
-                            Last activity: <time>' + timeDifference(current, new Date(element.updated_at)) + '</time> \
+                            Last activity: <time>'+ timeDifference(current, new Date(element.updated_at)) +'</time> \
                           </div> \
                         </div> \
                       </li>';
-                                        i++;
-                                      }
-                                    }
-                                  });
+                    i++;
+                  }
+                }
+              });
 
-                                  localStorage.removeItem('open-issues-react');
-                                  localStorage.setItem('open-issues-react', htmlReact);
-                                  Cookies.set('open-issues-react', true, { expires: 1 });
-                                  $('.open-issues-react').append(htmlReact);
-                                });
-                              }).catch(function (err) {
-                                console.log('Fetch Error :-S', err);
-                              });
-                            }
+              localStorage.removeItem('open-issues-react');
+              localStorage.setItem('open-issues-react', htmlReact);
+              Cookies.set('open-issues-react', true, { expires: 1 });
+              $('.open-issues-react').append(htmlReact);
 
-                            var htmlGo = '';
+            });
 
-                            if (typeof Cookies.get('open-issues-go') !== 'undefined') {
-                              $('.open-issues-go').append(localStorage.getItem('open-issues-go'));
-                            } else {
-                              fetch('https://api.github.com/repos/status-im/status-go/issues?sort=created&per_page=30').then(function (response) {
-                                if (response.status !== 200) {
-                                  console.log('Looks like there was a problem. Status Code: ' + response.status);
-                                  return;
-                                }
+          }
+        )
+        .catch(function(err) {
+          console.log('Fetch Error :-S', err);
+        });
+    }
 
-                                response.json().then(function (data) {
+    var htmlGo = '';
 
-                                  var i = 0;
+    if (typeof Cookies.get('open-issues-go') !== 'undefined') {
+      $('.open-issues-go').append(localStorage.getItem('open-issues-go'));
+    } else {
+      fetch('https://api.github.com/repos/status-im/status-go/issues?sort=created&per_page=30')
+        .then(
+          function(response) {
+            if (response.status !== 200) {
+              console.log('Looks like there was a problem. Status Code: '
+                + response.status);
+              return;
+            }
 
-                                  data.forEach(function (element) {
-                                    if (typeof element.pull_request === 'undefined') {
-                                      if (i < 4) {
-                                        var current = new Date();
-                                        var labelsHtml = '<div class="tags">';
-                                        var labels = element.labels;
-                                        labels.forEach(function (label) {
-                                          labelsHtml += '<div class="tag">' + label.name + '</div>';
-                                        });
-                                        labelsHtml += '</div>';
-                                        htmlGo += '<li> \
-                        <div class="number">#' + element.number + '</div> \
+            response.json().then(function(data) {
+
+              var i = 0;
+
+              data.forEach(function(element) {
+                if (typeof element.pull_request === 'undefined') {
+                  if(i < 4){
+                    var current= new Date();
+                    var labelsHtml = '<div class="tags">';
+                    var labels = element.labels;
+                    labels.forEach(function(label){
+                      labelsHtml += '<div class="tag">'+ label.name +'</div>'
+                    });
+                    labelsHtml += '</div>';
+                    htmlGo += '<li> \
+                        <div class="number">#'+ element.number +'</div> \
                         <div class="details"> \
-                          <b><a href="' + element.html_url + '" target="_blank">' + element.title + '</a></b> \
-                            ' + labelsHtml + ' \
+                          <b><a href="'+ element.html_url +'" target="_blank">' + element.title + '</a></b> \
+                            '+ labelsHtml +' \
                           <div class="opened"> \
-                            Opened: <time>' + timeDifference(current, new Date(element.created_at)) + '</time> \
+                            Opened: <time>'+ timeDifference(current, new Date(element.created_at)) +'</time> \
                           </div> \
                           <div class="activity"> \
-                            Last activity: <time>' + timeDifference(current, new Date(element.updated_at)) + '</time> \
+                            Last activity: <time>'+ timeDifference(current, new Date(element.updated_at)) +'</time> \
                           </div> \
                         </div> \
                       </li>';
-                                        i++;
-                                      }
-                                    }
-                                  });
+                    i++;
+                  }
+                }
+              });
 
-                                  localStorage.removeItem('open-issues-go');
-                                  localStorage.setItem('open-issues-go', htmlGo);
-                                  Cookies.set('open-issues-go', true, { expires: 1 });
-                                  $('.open-issues-go').append(htmlGo);
-                                });
-                              }).catch(function (err) {
-                                console.log('Fetch Error :-S', err);
-                              });
-                            }
-                          }
+              localStorage.removeItem('open-issues-go');
+              localStorage.setItem('open-issues-go', htmlGo);
+              Cookies.set('open-issues-go', true, { expires: 1 });
+              $('.open-issues-go').append(htmlGo);
 
-                          $('.contributor .contributor-trigger').on('click', function (event) {
-                            event.preventDefault();
-                          });
+            });
 
-                          if ($('.right-sub-navigation').length) {
-                            $('.editor-content h1, .editor-content h2, .editor-content h3').each(function (index, element) {
-                              var id = $(this).attr('id');
-                              var title = $(this).text();
-                              $('.right-sub-navigation ul').append('<li class="li-' + $(this)[0].nodeName.toLowerCase() + '"><a href="#' + id + '">' + title + '</a></li>');
-                            });
-                            $('.right-sub-navigation').stick_in_parent({
-                              offset_top: 30
-                            });
-                            $('.right-sub-navigation a').on('click', function () {
-                              var id = $(this).attr('href');
-                              $('html, body').animate({
-                                scrollTop: $(id).offset().top - 50
-                              }, 500);
-                              return false;
-                            });
-                          }
+          }
+        )
+        .catch(function(err) {
+          console.log('Fetch Error :-S', err);
+        });
+    }
 
-                          function timeDifference(current, previous) {
+  }
 
-                            var msPerMinute = 60 * 1000;
-                            var msPerHour = msPerMinute * 60;
-                            var msPerDay = msPerHour * 24;
-                            var msPerMonth = msPerDay * 30;
-                            var msPerYear = msPerDay * 365;
+  $('.contributor .contributor-trigger').on('click', function (event) {
+    event.preventDefault();
+  });
 
-                            var elapsed = current - previous;
+  if($('.right-sub-navigation').length){
+    $('.editor-content h1, .editor-content h2, .editor-content h3').each(function (index, element) {
+      var id = $(this).attr('id');
+      var title = $(this).text();
+      $('.right-sub-navigation ul').append('<li class="li-'+ $(this)[0].nodeName.toLowerCase() +'"><a href="#'+ id +'">' + title + '</a></li>');
+    });
+    $('.right-sub-navigation').stick_in_parent({
+      offset_top: 30
+    });
+    $('.right-sub-navigation a').on('click', function() {
+      var id = $(this).attr('href');
+      $('html, body').animate({
+        scrollTop: $(id).offset().top - 50
+      }, 500);
+      return false;
+    });
+  }
 
-                            if (elapsed < msPerMinute) {
-                              return Math.round(elapsed / 1000) + ' seconds ago';
-                            } else if (elapsed < msPerHour) {
-                              return Math.round(elapsed / msPerMinute) + ' minutes ago';
-                            } else if (elapsed < msPerDay) {
-                              return Math.round(elapsed / msPerHour) + ' hours ago';
-                            } else if (elapsed < msPerMonth) {
-                              return Math.round(elapsed / msPerDay) + ' days ago';
-                            } else if (elapsed < msPerYear) {
-                              return Math.round(elapsed / msPerMonth) + ' months ago';
-                            } else {
-                              return Math.round(elapsed / msPerYear) + ' years ago';
-                            }
-                          }
-                        });
-                      }, {}] }, {}, [1]);
-                  }, {}] }, {}, [1]);
-              }, {}] }, {}, [1]);
-          }, {}] }, {}, [1]);
-      }, {}] }, {}, [1]);
-  }, {}] }, {}, [1]);
+  function timeDifference(current, previous) {
+    
+    var msPerMinute = 60 * 1000;
+    var msPerHour = msPerMinute * 60;
+    var msPerDay = msPerHour * 24;
+    var msPerMonth = msPerDay * 30;
+    var msPerYear = msPerDay * 365;
+    
+    var elapsed = current - previous;
+    
+    if (elapsed < msPerMinute) {
+      return Math.round(elapsed/1000) + ' seconds ago';   
+    }
+    
+    else if (elapsed < msPerHour) {
+      return Math.round(elapsed/msPerMinute) + ' minutes ago';   
+    }
+    
+    else if (elapsed < msPerDay ) {
+      return Math.round(elapsed/msPerHour ) + ' hours ago';   
+    }
 
+    else if (elapsed < msPerMonth) {
+      return Math.round(elapsed/msPerDay) + ' days ago';   
+    }
+    
+    else if (elapsed < msPerYear) {
+      return Math.round(elapsed/msPerMonth) + ' months ago';   
+    }
+    
+    else {
+      return Math.round(elapsed/msPerYear ) + ' years ago';   
+    }
+}
 
-},{}]},{},[1])
-//# sourceMappingURL=main.js.map
+});


### PR DESCRIPTION
Fixes for a loop caused in `yarn run gulp watch` which created multiple wrappers around `themes/navy/source/js/main.js`.

Changes:
* un-minify `main.js`, caused by bundle lop
* drop useless browserify, drop `bundle` stage
* create `minify` task for JS
* make `compress` task affect only CSS
* make site use the `main.min.js`