### PR TITLE
Update linter references to new make target

### DIFF
--- a/source/build_status/first_pr_guide.md
+++ b/source/build_status/first_pr_guide.md
@@ -58,8 +58,7 @@ Make whatever changes to the app you've got in mind in your local branch.
 Run the linter to fix any formatting errors:
 
 ```bash
-make shell
-lein cljfmt fix
+make lint-fix
 ```
 
 In a second terminal window, run the tests with `sudo make test-auto`.  This will run the tests continually in the background.

--- a/source/build_status/makefile_tour.md
+++ b/source/build_status/makefile_tour.md
@@ -74,7 +74,8 @@ There are three targets related to testing.
 * `make test` - Runs all the NodeJS unit tests once and print the output to the screen.
 * `make test-auto` - Runs all the NodeJS unit tests in interactive mode, monitoring the code base for any changes and then re-running the test suite when changes are detected.
 * `make coverage` - Runs the NodeJS unit tests once and generate a coverage report.
-* `make lint` - Runs the linter and fix any formatting issues.
+* `make lint` - Runs the linter and reports any formatting issues.
+* `make lint-fix` - Runs the linter and automatically fixes any formatting issues.
 
 ## Android Targets
 


### PR DESCRIPTION
@jakubgs  Here are the accompanying documentation updates for the new `make lint-fix` target on `status-react` once [status-react/#9751](https://github.com/status-im/status-react/pull/9751) is merged.