### PR TITLE
add 20x bottom margin to download links for /nft-nyc

### DIFF
--- a/themes/navy/layout/nft-nyc.ejs
+++ b/themes/navy/layout/nft-nyc.ejs
@@ -29,8 +29,8 @@
 									</li>
 								</ul>
 								<div class="d-flex flex-wrap">
-									<a href="<%- get_build_url('official', 'APPSTORE') %>" class="m-r-20 download"><%- image_tag("/img/app-store.svg") %></a>
-									<a href="<%- get_build_url('official', 'PLAYSTORE') %>" class="m-r-20 download"><%- image_tag("/img/google-play.svg") %></a>
+									<a href="<%- get_build_url('official', 'APPSTORE') %>" class="m-r-20 m-b-20 download"><%- image_tag("/img/app-store.svg") %></a>
+									<a href="<%- get_build_url('official', 'PLAYSTORE') %>" class="m-r-20 m-b-20 download"><%- image_tag("/img/google-play.svg") %></a>
 									<a href="<%- get_build_url('official', 'DIRECT_APK') %>" class="download"><%- image_tag("/img/apk.svg") %></a>
 								</div>
 							</div>

--- a/themes/navy/source/scss/main.scss
+++ b/themes/navy/source/scss/main.scss
@@ -403,6 +403,9 @@ h4{
 .m-r-20{
     margin-right: 20px;
 }
+.m-b-20{
+    margin-bottom: 20px;
+}
 .m-b-25{
     margin-bottom: 25px;
 }


### PR DESCRIPTION
Fix for download link styling issue:
![](https://cdn.discordapp.com/attachments/626405456168091648/679078570139844608/Screen_Shot_2020-02-17_at_4.15.24_PM.png)
Not sure if this is the right way to fix it but it works.