### PR TITLE
add link to phishing PSA on Discourse

### DIFF
--- a/themes/navy/languages/en.yml
+++ b/themes/navy/languages/en.yml
@@ -522,6 +522,7 @@ site:
       content-9:
         title: "Signing Phrase to protect from phishing attacks"
         description: "Status implements a signing phrase required to confirm and “sign” all transactions. The signing phrase is a 3 word phrase randomly generated for you and stored locally on your device that is presented each time you attempt to send a transaction. You will be presented your signing phrase and be required to accept it before a transaction will be confirmed. If you do not recognize your three words, or are not presented with the three words at all, cancel the transaction, log out of Status and report the issue to %s"
+        link: "Learn more about phishing"
       content-10:
         title: "Rigorous Auditing"
         description-1: "As we reach major milestones in development, after rounds of internal review and auditing, we reach out to industry leading, third-party auditing firms to verify our sanity, and double/triple check the work that we do. These security audits are not guarantees of security in the projects they pertain to. They are additional checks from objective third parties to help bolster confidence in the security of intended functionality."

--- a/themes/navy/layout/security.ejs
+++ b/themes/navy/layout/security.ejs
@@ -58,6 +58,7 @@
 					<p class="p-large"><%- __('site.security.security-content.content-8.description') %></p>
 					<h3><%- __('site.security.security-content.content-9.title') %></h3>
 					<p class="p-large"><%- __('site.security.security-content.content-9.description', '<a href="mailto:security@status.im">security@status.im</a>') %></p>
+					<p><a href="https://discuss.status.im/t/psa-general-security-information/1562" target="_blank" class="link-arrow"><%- __('site.security.security-content.content-9.link') %></a></p>
 					<h3><%- __('site.security.security-content.content-10.title') %></h3>
 					<p class="p-large"><%- __('site.security.security-content.content-10.description-1') %></p>
 					<p class="p-large"><%- __('site.security.security-content.content-10.description-2', '<a href="https://github.com/status-im/status-security#audits">security repository</a>') %></p>


### PR DESCRIPTION
Add link to new post about phishing in the phishing section of security page.
![phish](https://user-images.githubusercontent.com/2212681/75294594-23751300-5829-11ea-9f81-8f84c42d6408.png)