### PR TITLE
Update community group hashtag in the Get involved` page

### DIFF
--- a/themes/navy/languages/ar.yml
+++ b/themes/navy/languages/ar.yml
@@ -265,32 +265,26 @@ site:
         link-2: 'إرسال مجموعة جديدة'
       community-groups:
         account-group-1:
-          link: '#Status-سفراء'
           description: 'مجموعه من الأشخاص المتفانيين في المساعدة والمساهمة وبناء مجمعStatus   '
           occupation: منظم
           name: لنا
         account-group-2:
-          link: '#Status الكورية'
           description: 'مجموعة من المطورين الشغوفين والمصنعين والمبدعين والمتحمسين الموجودين في كوريا الجنوبية.'
           occupation: منظم
           name: 'جينهو جانغ'
         account-group-3:
-          link: '#status-الاسبانيه'
           description: 'Status  في إسبانيا'
           occupation: منظم
           name: 'لالو جارزا'
         account-group-4:
-          link: '#status-الصينية'
           description: 'Status بالصينية '
           occupation: منظم
           name: 'ستيفن تشو'
         account-group-5:
-          link: الفلاسفة
           description: 'ما معني الحياة ؟'
           occupation: منظم
           name: ارسطو
         account-group-6:
-          link: '#الحالة-الفلبين'
           description: 'الحالة للمجتمع الفلبيني'
           occupation: منظم
   security:

--- a/themes/navy/languages/en.yml
+++ b/themes/navy/languages/en.yml
@@ -461,12 +461,12 @@ site:
         link-2: "Submit a new group"
       community-groups:
         account-group-1:
-          link: "#Status-ambassadors"
+          link: "#statusphere"
           description: "A group of people dedicated to helping, contributing, and building the Status community."
           occupation: "Organizer"
           name: "Us"
         account-group-2:
-          link: "#Status-Korean"
+          link: "#status-korean"
           description: "A group of passionate developers, makers, creators, and enthusiasts based in South Korea."
           occupation: "Organizer"
           name: "Jinho Jang"

--- a/themes/navy/languages/en.yml
+++ b/themes/navy/languages/en.yml
@@ -461,32 +461,26 @@ site:
         link-2: "Submit a new group"
       community-groups:
         account-group-1:
-          link: "#statusphere"
           description: "A group of people dedicated to helping, contributing, and building the Status community."
           occupation: "Organizer"
           name: "Us"
         account-group-2:
-          link: "#status-korean"
           description: "A group of passionate developers, makers, creators, and enthusiasts based in South Korea."
           occupation: "Organizer"
           name: "Jinho Jang"
         account-group-3:
-          link: "#status-spanish"
           description: "Status en Español"
           occupation: "Organizer"
           name: "Lalo Garza"
         account-group-4:
-          link: "#status-chinese"
           description: "Status in Chinese"
           occupation: "Organizer"
           name: "Steven Zhu"
         account-group-5:
-          link: "#philosophers"
           description: "What is the meaning of life?"
           occupation: "Organizer"
           name: "Aristotle"
         account-group-6:
-          link: "#status-philippines"
           description: "Status for the Filipino community"
           occupation: "Organizer"
           name: "Ken"

--- a/themes/navy/languages/es.yml
+++ b/themes/navy/languages/es.yml
@@ -261,32 +261,26 @@ site:
         link-2: 'Presentar un nuevo grupo'
       community-groups:
         account-group-1:
-          link: '#status-ambassadors'
           description: 'Un grupo de personas dedicadas a ayudar, contribuir y construir la comunidad de Status.'
           occupation: Organizador
           name: Nosotros
         account-group-2:
-          link: '#status-korean'
           description: 'Un grupo de apasionados desarrolladores, creadores y entusiastas con sede en Corea del Sur.'
           occupation: Organizador
           name: 'Jinho Jang'
         account-group-3:
-          link: '# status-spanish'
           description: 'Status en español'
           occupation: Organizador
           name: 'Lalo Garza'
         account-group-4:
-          link: '#status-chinese'
           description: 'Status en chino'
           occupation: Organizador
           name: 'Steven Zhu'
         account-group-5:
-          link: '#philosophers'
           description: '¿Cuál es el significado de la vida?'
           occupation: Organizador
           name: Aristotle
         account-group-6:
-          link: '#status-philippines'
           description: 'Status para la comunidad Filipina'
           occupation: Organizador
   security:

--- a/themes/navy/languages/fr.yml
+++ b/themes/navy/languages/fr.yml
@@ -265,32 +265,26 @@ site:
         link-2: 'Soumettre un nouveau groupe'
       community-groups:
         account-group-1:
-          link: '#Status-ambassadors'
           description: 'Un groupe de personnes dédiées à aider, contribuer et construire la communauté Status.'
           occupation: Organisateur
           name: Nous
         account-group-2:
-          link: '#Status-Korean'
           description: 'Un groupe de développeurs, fabricants, créateurs et passionnés passionnés basés en Corée du Sud.'
           occupation: Organisateur
           name: 'Jinho Jang'
         account-group-3:
-          link: '#status-spanish'
           description: 'Status en Español'
           occupation: Organisateur
           name: 'Lalo Garza'
         account-group-4:
-          link: '#status-chinese'
           description: 'Status en chinois'
           occupation: Organisateur
           name: 'Steven Zhu'
         account-group-5:
-          link: '#philosophes'
           description: 'Quel est le sens de la vie?'
           occupation: Organisateur
           name: Aristotle
         account-group-6:
-          link: '#status-philippines'
           description: 'Status pour la communauté philippine'
           occupation: Organisateur
   security:

--- a/themes/navy/languages/id.yml
+++ b/themes/navy/languages/id.yml
@@ -262,32 +262,26 @@ site:
         link-2: 'Kirim grup baru'
       community-groups:
         account-group-1:
-          link: '# Status-duta besar'
           description: 'Sekelompok orang yang berdedikasi untuk membantu, berkontribusi, dan membangun komunitas Status.'
           occupation: Penyelenggara
           name: Kami
         account-group-2:
-          link: '# Status-Korea'
           description: 'Sekelompok pengembang, pembuat, pencipta, dan penggemar yang bersemangat yang berbasis di Korea Selatan.'
           occupation: Penyelenggara
           name: 'Jinho Jang'
         account-group-3:
-          link: '# status-spanyol'
           description: 'Status en Español'
           occupation: Penyelenggara
           name: 'Lalo Garza'
         account-group-4:
-          link: '# status-cina'
           description: 'Status dalam bahasa Cina'
           occupation: Penyelenggara
           name: 'Steven Zhu'
         account-group-5:
-          link: '#philosophers'
           description: 'apa arti kehidupan?'
           occupation: Penyelenggara
           name: Aristotle
         account-group-6:
-          link: '#status-Philippines'
           description: 'Status untuk komunitas Filipina'
           occupation: Penyelenggara
   security:

--- a/themes/navy/languages/ko.yml
+++ b/themes/navy/languages/ko.yml
@@ -265,32 +265,26 @@ site:
         link-2: '새 그룹 등록하기'
       community-groups:
         account-group-1:
-          link: '#Status-ambassadors'
           description: '스테이터스 커뮤니티를 돕고, 기여하고, 만들어나가는 데 전념하는 사람들의 그룹.'
           occupation: 주최자
           name: '우리 모두'
         account-group-2:
-          link: '#Status-Korean'
           description: '한국에 기반한 열정적인 개발자, 메이커, 크리에이터, 애호가들의 모임.'
           occupation: 주최자
           name: 장진호
         account-group-3:
-          link: '#status-spanish'
           description: '스테이터스 스페인어 커뮤니티'
           occupation: 주최자
           name: '랄로 가르자'
         account-group-4:
-          link: '#status-chinese'
           description: '스테이터스 중국어 커뮤니티'
           occupation: 주최자
           name: '스티븐 주'
         account-group-5:
-          link: '#philosophers'
           description: '인생의 의미는 무엇인가?'
           occupation: 주최자
           name: 아리스토텔레스
         account-group-6:
-          link: '#status-philippines'
           description: '스테이터스 필리핀 커뮤니티'
           occupation: 주최자
   security:

--- a/themes/navy/languages/ru.yml
+++ b/themes/navy/languages/ru.yml
@@ -242,27 +242,22 @@ site:
         link-2: 'Добавить новую группу'
       community-groups:
         account-group-1:
-          link: '# Status-послы'
           description: 'Группа людей, посвященных помощи, содействию и созданию сообщества Status.'
           occupation: Организатор
           name: Нам
         account-group-2:
-          link: '# Status-корейский'
           description: 'Группа увлеченных разработчиков, производителей, создателей и энтузиастов из Южной Кореи.'
           occupation: Организатор
           name: 'Jinho Чан'
         account-group-3:
-          link: '# Status-испанский'
           description: 'Status на испанском языке'
           occupation: Организатор
           name: 'Лало Гарза'
         account-group-4:
-          link: '# Status-китайский'
           description: 'Status на китайском языке'
           occupation: Организатор
           name: 'Стивен Чжу'
         account-group-5:
-          link: '#философы #'
           description: 'В чем смысл жизни?'
           occupation: Организатор
           name: Аристотель

--- a/themes/navy/languages/tl.yml
+++ b/themes/navy/languages/tl.yml
@@ -265,32 +265,26 @@ site:
         link-2: 'Magsumite ng isang bagong grupo'
       community-groups:
         account-group-1:
-          link: '#Status-ambassadors'
           description: 'Isang pangkat ng mga taong nakatuon sa pagtulong, pagbibigay, at pagbuo ng Status sa komunidad.'
           occupation: Organizer
           name: Kami
         account-group-2:
-          link: '#Status-Korean'
           description: 'Isang pangkat ng mga madamdaming developer, tagagawa, tagalikha, at mga mahilig na nakabase sa South Korea.'
           occupation: Organizer
           name: 'Jinho Jang'
         account-group-3:
-          link: '#status-spanish'
           description: 'Status sa Español'
           occupation: Organizer
           name: 'Lalo Garza'
         account-group-4:
-          link: '#status-chinese'
           description: 'Status sa Chinese'
           occupation: Organizer
           name: 'Steven Zhu'
         account-group-5:
-          link: '#philosophers'
           description: 'Ano ang kahulugan ng buhay?'
           occupation: Organizer
           name: Aristotle
         account-group-6:
-          link: '#status-philippines'
           description: 'Status para sa mga Filipino community'
           occupation: Organizer
   security:

--- a/themes/navy/languages/zh.yml
+++ b/themes/navy/languages/zh.yml
@@ -264,32 +264,26 @@ site:
         link-2: 提交新组
       community-groups:
         account-group-1:
-          link: Status大使
           description: 一群致力于帮助，贡献和建立Status社区的人。
           occupation: 组织者
           name: 我们
         account-group-2:
-          link: Status-韩语
           description: 一群充满激情的开发人员，制作人，创作者和爱好者，总部设在韩国。
           occupation: 组织者
           name: Jinho张
         account-group-3:
-          link: Statu西班牙
           description: 西班牙
           occupation: 组织者
           name: 'Lalo Garza'
         account-group-4:
-          link: 中文
           description: 中文
           occupation: 组织者
           name: 'Steven 朱'
         account-group-5:
-          link: '#philosophers'
           description: 的意义是什么？
           occupation: 组织者
           name: 亚里士多德
         account-group-6:
-          link: '#status-philippines'
           description: 'Status 菲律宾社区'
           occupation: 组织者
   security:

--- a/themes/navy/layout/community.ejs
+++ b/themes/navy/layout/community.ejs
@@ -42,7 +42,7 @@
 				<div class="col-lg-6 col-xl-4">
 					<div class="account-creation">
 						<%- image_tag("/img/status-ambassadors.svg") %>
-						<a href="https://join.status.im/chat/public/statusphere" target="_blank"><%- __('site.get-involved.community.community-groups.account-group-1.link') %></a>
+						<a href="https://join.status.im/chat/public/statusphere" target="_blank">#statusphere</a>
 						<p><%- __('site.get-involved.community.community-groups.account-group-1.description') %></p>
 						<div class="meta">
 							<span class="occupation"><%- __('site.get-involved.community.community-groups.account-group-1.occupation') %></span>
@@ -53,7 +53,7 @@
 				<div class="col-lg-6 col-xl-4">
 					<div class="account-creation">
 						<%- image_tag("/img/status-korea.svg") %>
-						<a href="https://join.status.im/chat/public/status-korean" target="_blank"><%- __('site.get-involved.community.community-groups.account-group-2.link') %></a>
+						<a href="https://join.status.im/chat/public/status-korean" target="_blank">#status-korean</a>
 						<p><%- __('site.get-involved.community.community-groups.account-group-2.description') %></p>
 						<div class="meta">
 							<span class="occupation"><%- __('site.get-involved.community.community-groups.account-group-2.occupation') %></span>
@@ -64,7 +64,7 @@
 				<div class="col-lg-6 col-xl-4">
 					<div class="account-creation">
 						<%- image_tag("/img/status-en-espanol.svg") %>
-						<a href="https://join.status.im/chat/public/status-spanish" target="_blank"><%- __('site.get-involved.community.community-groups.account-group-3.link') %></a>
+						<a href="https://join.status.im/chat/public/status-spanish" target="_blank">#status-spanish</a>
 						<p><%- __('site.get-involved.community.community-groups.account-group-3.description') %></p>
 						<div class="meta">
 							<span class="occupation"><%- __('site.get-involved.community.community-groups.account-group-3.occupation') %></span>
@@ -75,7 +75,7 @@
 				<div class="col-lg-6 col-xl-4">
 					<div class="account-creation">
 						<%- image_tag("/img/status-chinese.svg") %>
-						<a href="https://join.status.im/chat/public/status-chinese" target="_blank"><%- __('site.get-involved.community.community-groups.account-group-4.link') %> </a>
+						<a href="https://join.status.im/chat/public/status-chinese" target="_blank">#status-chinese</a>
 						<p><%- __('site.get-involved.community.community-groups.account-group-4.description') %></p>
 						<div class="meta">
 							<span class="occupation"><%- __('site.get-involved.community.community-groups.account-group-4.occupation') %></span>
@@ -86,7 +86,7 @@
 				<div class="col-lg-6 col-xl-4">
 					<div class="account-creation">
 						<%- image_tag("/img/status-philippines.svg") %>
-						<a href="https://join.status.im/chat/public/status-philippines" target="_blank"> <%- __('site.get-involved.community.community-groups.account-group-6.link') %> </a>
+						<a href="https://join.status.im/chat/public/status-philippines" target="_blank">#status-philippines</a>
 						<p><%- __('site.get-involved.community.community-groups.account-group-6.description') %></p>
 						<div class="meta">
 							<span class="occupation"><%- __('site.get-involved.community.community-groups.account-group-6.occupation') %></span>
@@ -97,7 +97,7 @@
 				<div class="col-lg-6 col-xl-4">
 					<div class="account-creation">
 						<%- image_tag("/img/philosophers.svg") %>
-						<a href="https://join.status.im/chat/public/philosophers" target="_blank"><%- __('site.get-involved.community.community-groups.account-group-5.link') %></a>
+						<a href="https://join.status.im/chat/public/philosophers" target="_blank">#philosophers</a>
 						<p><%- __('site.get-involved.community.community-groups.account-group-5.description') %></p>
 						<div class="meta">
 							<span class="occupation"><%- __('site.get-involved.community.community-groups.account-group-5.occupation') %></span>

--- a/themes/navy/layout/community.ejs
+++ b/themes/navy/layout/community.ejs
@@ -42,7 +42,7 @@
 				<div class="col-lg-6 col-xl-4">
 					<div class="account-creation">
 						<%- image_tag("/img/status-ambassadors.svg") %>
-						<a href="https://join.status.im/chat/public/statusphere" target="_blank">#statusphere</a>
+						<a href="https://join.status.im/statusphere" target="_blank">#statusphere</a>
 						<p><%- __('site.get-involved.community.community-groups.account-group-1.description') %></p>
 						<div class="meta">
 							<span class="occupation"><%- __('site.get-involved.community.community-groups.account-group-1.occupation') %></span>
@@ -53,7 +53,7 @@
 				<div class="col-lg-6 col-xl-4">
 					<div class="account-creation">
 						<%- image_tag("/img/status-korea.svg") %>
-						<a href="https://join.status.im/chat/public/status-korean" target="_blank">#status-korean</a>
+						<a href="https://join.status.im/status-korean" target="_blank">#status-korean</a>
 						<p><%- __('site.get-involved.community.community-groups.account-group-2.description') %></p>
 						<div class="meta">
 							<span class="occupation"><%- __('site.get-involved.community.community-groups.account-group-2.occupation') %></span>
@@ -64,7 +64,7 @@
 				<div class="col-lg-6 col-xl-4">
 					<div class="account-creation">
 						<%- image_tag("/img/status-en-espanol.svg") %>
-						<a href="https://join.status.im/chat/public/status-spanish" target="_blank">#status-spanish</a>
+						<a href="https://join.status.im/status-spanish" target="_blank">#status-spanish</a>
 						<p><%- __('site.get-involved.community.community-groups.account-group-3.description') %></p>
 						<div class="meta">
 							<span class="occupation"><%- __('site.get-involved.community.community-groups.account-group-3.occupation') %></span>
@@ -75,7 +75,7 @@
 				<div class="col-lg-6 col-xl-4">
 					<div class="account-creation">
 						<%- image_tag("/img/status-chinese.svg") %>
-						<a href="https://join.status.im/chat/public/status-chinese" target="_blank">#status-chinese</a>
+						<a href="https://join.status.im/status-chinese" target="_blank">#status-chinese</a>
 						<p><%- __('site.get-involved.community.community-groups.account-group-4.description') %></p>
 						<div class="meta">
 							<span class="occupation"><%- __('site.get-involved.community.community-groups.account-group-4.occupation') %></span>
@@ -86,7 +86,7 @@
 				<div class="col-lg-6 col-xl-4">
 					<div class="account-creation">
 						<%- image_tag("/img/status-philippines.svg") %>
-						<a href="https://join.status.im/chat/public/status-philippines" target="_blank">#status-philippines</a>
+						<a href="https://join.status.im/status-philippines" target="_blank">#status-philippines</a>
 						<p><%- __('site.get-involved.community.community-groups.account-group-6.description') %></p>
 						<div class="meta">
 							<span class="occupation"><%- __('site.get-involved.community.community-groups.account-group-6.occupation') %></span>
@@ -97,7 +97,7 @@
 				<div class="col-lg-6 col-xl-4">
 					<div class="account-creation">
 						<%- image_tag("/img/philosophers.svg") %>
-						<a href="https://join.status.im/chat/public/philosophers" target="_blank">#philosophers</a>
+						<a href="https://join.status.im/philosophers" target="_blank">#philosophers</a>
 						<p><%- __('site.get-involved.community.community-groups.account-group-5.description') %></p>
 						<div class="meta">
 							<span class="occupation"><%- __('site.get-involved.community.community-groups.account-group-5.occupation') %></span>


### PR DESCRIPTION
# Get Involved page updates

**Summary**: Community Group on display corrected to its proper hashtag

**Updated**:

1. `#Status-ambassadors -> #statusphere`
2. `#Status-Korean -> #status-korean`
3. New url scheme for public chat