### PR TITLE
update build instructions with new Makefile targets

### DIFF
--- a/source/build_status/makefile_tour.md
+++ b/source/build_status/makefile_tour.md
@@ -24,26 +24,13 @@ You will need to run one of each target in separate terminals from the following
 
 ## Building Clojure
 
-`make startdev-**` is the set of targets that starts up Figwheel and the Clojurescript REPL.  Depending on what environment you're coding on, you'll use one of the following targets.
+`make run-clojure` is at target that compiles Clojure into JavaScript, watches for changes on cljs files, and hot-reloads code in the app
 
-* `make startdev-android-real` - For using a real Android device for development
-* `make startdev-android-avd` - For using a virtual Android device for development
-* `make startdev-android-genymotion` - For using the Genymotion simulator for Android development
-* `make startdev-ios-real` - For using a real iOS device for development
-* `make startdev-ios-simulator` - For using the XCode IOS simulator for development
-* ~~`make startdev-desktop` - For developing for Status Desktop~~
-
-Note: If developing with a real Android device, make sure to also run `make android-ports` or the REPL won't connect to your device.
+__Note__: If developing with a real Android device, make sure to also run `make android-ports` or the REPL won't connect to your device.
 
 ## Building React Native
 
-`make react-native-**` is the set of targets that sets up the react-native code manager for development.  Run this in a separate terminal after you run `make-startdev-**` with your preferred device/simulator.  
-
-OS targets
-
-* `make react-native-android`
-* `make react-native-ios`
-* ~~`make react-native-desktop`~~
+`make run-metro` is the target that sets up the react-native code manager for development.  Run this in a separate terminal along `make run-clojure`.  
 
 ## Building the App
 

--- a/source/technical/build_status/index.md
+++ b/source/technical/build_status/index.md
@@ -64,15 +64,7 @@ After you installed all the dependencies, you need to run two processes — the 
 
 ### 1. Build process
 
-Just run **one** of these commands in the first terminal window:
-
-```bash
-make startdev-ios-simulator
-make startdev-ios-real
-make startdev-android-avd
-make startdev-android-genymotion
-make startdev-android-real
-```
+Just run make `run-clojure` in the first terminal window.
 
 By doing this you will start the compilation of ClojureScript sources and run re-frisk (a tool for debugging). You should wait until it shows you `Prompt will show when Figwheel connects to your application` before running the React Native packager.
 
@@ -86,8 +78,10 @@ For additional information check the following:
 Do this in the second terminal window:
 
 ```bash
-make react-native-android # (ios and desktop are also available targets)
+make run-metro
 ```
+
+Which starts Metro bundler and watches JavaScript code changes.
 
 ## Build and run the application itself
 
@@ -178,11 +172,11 @@ Whenever the iOS NodeJS dependencies change, `make nix-update-pods` should be ru
 
 ### Android Gradle Maven dependencies
 
-Whenever the Android project changes in terms of Gradle dependencies, `make nix-update-gradle` should be run in order to update `nix/mobile/android/maven-and-npm-deps/maven/maven-sources.nix`.
+Whenever the Android project changes in terms of Gradle dependencies, `make nix-update-gradle` should be run in order to update `nix/deps/gradle/deps.json`.
 
-### Leiningen Maven dependencies
+### Clojure Maven dependencies
 
-Whenever the Leiningen dependencies change, `make nix-update-lein` should be run in order to update `nix/lein/lein-project-deps.nix`.
+Whenever the Clojure dependencies change, `make nix-update-clojure` should be run in order to update `nix/deps/clojure/deps.json`.
 
 ### Fastlane Ruby dependencies
 


### PR DESCRIPTION
This updates build instructions to match changes in https://github.com/status-im/status-react/pull/10647 which refactors the `Makefile` to simplify and combine multiple redundant targets.