### PR TITLE
Fix the footer showing wrong translations

### DIFF
--- a/source/_data/nightlies.yml
+++ b/source/_data/nightlies.yml
@@ -1,7 +1,7 @@
-DIAWI: 'https://i.diawi.com/WJbyS6'
-APK: 'https://status-im.ams3.digitaloceanspaces.com/StatusIm-200616-025900-2038b9-nightly-universal.apk'
-IOS: 'https://status-im.ams3.digitaloceanspaces.com/StatusIm-200616-025900-2038b9-nightly.ipa'
+DIAWI: 'https://i.diawi.com/3tqD1q'
+APK: 'https://status-im.ams3.digitaloceanspaces.com/StatusIm-200622-025900-171497-nightly-universal.apk'
+IOS: 'https://status-im.ams3.digitaloceanspaces.com/StatusIm-200622-025900-171497-nightly.ipa'
 APP: null
 MAC: null
 WIN: null
-SHA: 'https://status-im.ams3.digitaloceanspaces.com/StatusIm-200616-025900-2038b9-nightly.sha256'
+SHA: 'https://status-im.ams3.digitaloceanspaces.com/StatusIm-200622-025900-171497-nightly.sha256'

--- a/themes/navy/languages/ar.yml
+++ b/themes/navy/languages/ar.yml
@@ -367,7 +367,9 @@ site:
       link-2: 'الانضمام إلى قناةStatus الآمنة '
   header:
     nav:
-      features: الميزات
+      features:
+        link: "الميزات"
+        title: "الميزات"
       get-involved:
         title: شاركنا
         description: 'Status هي مشروع مفتوح المصدر <br> التي أدلى بها الناس في جميع أنحاء العالم.'

--- a/themes/navy/languages/de.yml
+++ b/themes/navy/languages/de.yml
@@ -367,7 +367,9 @@ site:
       link-2: 'Status-Sicherheits-Kanal beitreten'
   header:
     nav:
-      features: Funktionen
+      features:
+        link: "Funktionen"
+        title: "Funktionen"
       get-involved:
         title: 'Machen Sie mit'
         description: 'Status ist ein Open-Source-Projekt <br>von Menschen auf der ganzen Welt.</br>'

--- a/themes/navy/languages/es.yml
+++ b/themes/navy/languages/es.yml
@@ -357,7 +357,9 @@ site:
       link-2: 'Únete al canal de seguridad de Status'
   header:
     nav:
-      features: Funciones
+      features:
+        link: "Funciones"
+        title: "Funciones"
       get-involved:
         title: Involucrate
         description: 'Status es un proyecto de código abierto <br>hecho por gente de todo el mundo.'

--- a/themes/navy/languages/fr.yml
+++ b/themes/navy/languages/fr.yml
@@ -361,7 +361,9 @@ site:
       link-2: 'Rejoindre Status Security Channel'
   header:
     nav:
-      features: Aspects
+      features:
+        link: "Aspects"
+        title: "Aspects"
       get-involved:
         title: 'S''impliquer'
         description: 'Status est un projet open source <br>réalisé par des gens du monde entier.'

--- a/themes/navy/languages/id.yml
+++ b/themes/navy/languages/id.yml
@@ -358,7 +358,9 @@ site:
       link-2: 'Bergabunglah dengan Saluran Keamanan Status'
   header:
     nav:
-      features: fitur
+      features:
+        link: "fitur"
+        title: "fitur"
       get-involved:
         title: Terlibat
         description: 'Status adalah proyek sumber terbuka <br> dibuat oleh orang-orang di seluruh dunia.'

--- a/themes/navy/languages/ko.yml
+++ b/themes/navy/languages/ko.yml
@@ -367,7 +367,12 @@ site:
       link-2: '스테이터스 보안 채널에 참가하기'
   header:
     nav:
-      features: 기능
+      features:
+        link: "기능"
+        title: "기능"
+        link-1: "모든 기능 보기"
+        link-2: "키카드"
+        description: "안전한 메신저, 암호화폐 지갑, <br>웹3 브라우저, 모두를 한번에"
       get-involved:
         title: 참여하기
         description: '스테이터스는 전세계 사람들이 <br> 함께 만들어가는 오픈소스 프로젝트입니다.'

--- a/themes/navy/languages/ru.yml
+++ b/themes/navy/languages/ru.yml
@@ -322,7 +322,9 @@ site:
       link-2: ' Присоединиться к каналу безопасности Status'
   header:
     nav:
-      features: Характеристики
+      features:
+        link: "Характеристики"
+        title: "Характеристики"
       get-involved:
         title: Участвовать
         description: 'Status-проект с открытым исходным кодом, <br>созданный людьми со всего мира</br>.'

--- a/themes/navy/languages/tl.yml
+++ b/themes/navy/languages/tl.yml
@@ -367,7 +367,9 @@ site:
       link-2: 'Sumali sa Status Security Channel'
   header:
     nav:
-      features: 'Mga tampok'
+      features:
+        link: "Mga tampok"
+        title: "Mga tampok"
       get-involved:
         title: Makialam
         description: 'Status ay isang bukas na pagkukunan na proyekto<br>ginawa ng mga tao sa lahat ng dako ng mundo'

--- a/themes/navy/languages/zh.yml
+++ b/themes/navy/languages/zh.yml
@@ -367,7 +367,9 @@ site:
       link-2: '加入Status 安全通道'
   header:
     nav:
-      features: 特征
+      features:
+        link: "特征"
+        title: "特征"
       get-involved:
         title: 加入
         description: 'Status 是一个开源项目， <br>被人在世界各地制造。'

--- a/themes/navy/layout/partial/footer.ejs
+++ b/themes/navy/layout/partial/footer.ejs
@@ -23,7 +23,7 @@
                     <h5><a data-toggle="collapse" href="#footer-nav-1" role="button" aria-expanded="true" aria-controls="footer-nav-1"><%- __('site.footer.product.title') %></a></h5>
                     <div class="collapse show" id="footer-nav-1">
                         <ul>
-                            <li><a href="<%- show_lang() %>/features/"><%- __('site.header.nav.features') %></a></li>
+                            <li><a href="<%- show_lang() %>/features/"><%- __('site.header.nav.features.title') %></a></li>
                             <li><a href="<%- show_lang() %>/security/"><%- __('site.header.nav.security') %></a></li>
                             <li><a href="<%- show_lang() %>/get/"><%- __('site.footer.product.apps') %></a></li>
                             <li><a href="<%- show_lang() %>/nightly/"><%- __('site.footer.product.nightly') %></a></li>


### PR DESCRIPTION
Due to the recent translation updates ([Line 926](https://github.com/status-im/status.im/commit/fbb8d150319c6d5fb8fbdc72e1a912dbd262d6cb#diff-fcb6c59c4a6e50dd6a2b69a176947f34L926)), the footer shows wrong translations

There is a Korean word in the "Product"
<img width="1451" alt="Screen Shot 2020-06-23 at 12 27 44 AM" src="https://user-images.githubusercontent.com/41753422/85305693-65b51500-b4e8-11ea-86ec-7b4208417902.png">


