### PR TITLE
Add open positions to the footer

### DIFF
--- a/source/_data/nightlies.yml
+++ b/source/_data/nightlies.yml
@@ -1,7 +1,7 @@
-DIAWI: 'https://i.diawi.com/EaPiSF'
-APK: 'https://status-im-builds.ams3.digitaloceanspaces.com/StatusIm-200724-025901-729a35-nightly-universal.apk'
-IOS: 'https://status-im-builds.ams3.digitaloceanspaces.com/StatusIm-200724-025901-729a35-nightly.ipa'
+DIAWI: 'https://i.diawi.com/vMa5ND'
+APK: 'https://status-im-builds.ams3.digitaloceanspaces.com/StatusIm-200803-083544-d0ce6f-nightly-universal.apk'
+IOS: 'https://status-im-builds.ams3.digitaloceanspaces.com/StatusIm-200803-083544-d0ce6f-nightly.ipa'
 APP: null
 MAC: null
 WIN: null
-SHA: 'https://status-im.ams3.digitaloceanspaces.com/StatusIm-200724-025901-729a35-nightly.sha256'
+SHA: 'https://status-im.ams3.digitaloceanspaces.com/StatusIm-200803-083544-d0ce6f-nightly.sha256'

--- a/themes/navy/languages/en.yml
+++ b/themes/navy/languages/en.yml
@@ -928,6 +928,7 @@ site:
       white-paper: "White Paper"
       media-kit: "Media Kit"
       analytics: "Analytics"
+      open_positions: "Open Positions"
     documentation:
       title: "Documentation"
     status-network:

--- a/themes/navy/layout/partial/footer.ejs
+++ b/themes/navy/layout/partial/footer.ejs
@@ -47,10 +47,10 @@
                         <li class="mt-4"><a href="<%- show_lang() %>/get-involved/"><%- __('site.link.get-involved') %></a></li>
                         <li class="mt-4"><a href="<%- show_lang() %>/about/"><%- __('site.header.nav.about') %></a></li>
                         <li class="mt-4"><a href="http://statusnetwork.com/press-kit/status/" target="_blank"><%- __('site.footer.status.media-kit') %></a></li>
-                        <!-- <li class="mt-4"><a href="<%- show_lang() %>/contribute/open_positions.html"><%- __('site.footer.status.jobs') %></a></li> -->
                         <li class="mt-4"><a href="https://our.status.im/"><%- __('site.header.nav.blog') %></a></li>
                         <li class="mt-4"><a href="/files/whitepaper.pdf" target="_blank"><%- __('site.footer.status.white-paper') %></a></li>
                         <li class="mt-4"><a href="https://analytics.status.im/" target="_blank"><%- __('site.footer.status.analytics') %></a></li>
+                        <li class="mt-4"><a href="/our_team/open_positions.html" target="_blank"><%- __('site.footer.status.open_positions') %></a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Add the open positions page under `Status` to the footer as per Jonny's request
<img width="1532" alt="Screen Shot 2020-08-03 at 11 12 23 PM" src="https://user-images.githubusercontent.com/41753422/89192084-d1f26080-d5de-11ea-9394-f7fce399a2ee.png">
