### PR TITLE
Add quarterly reports to the About page

### DIFF
--- a/source/_data/nightlies.yml
+++ b/source/_data/nightlies.yml
@@ -1,7 +1,7 @@
-DIAWI: 'https://i.diawi.com/vMa5ND'
-APK: 'https://status-im-builds.ams3.digitaloceanspaces.com/StatusIm-200803-083544-d0ce6f-nightly-universal.apk'
-IOS: 'https://status-im-builds.ams3.digitaloceanspaces.com/StatusIm-200803-083544-d0ce6f-nightly.ipa'
+DIAWI: 'https://i.diawi.com/uuDWF5'
+APK: 'https://status-im-builds.ams3.digitaloceanspaces.com/StatusIm-200810-025900-687223-nightly-universal.apk'
+IOS: 'https://status-im-builds.ams3.digitaloceanspaces.com/StatusIm-200810-025900-687223-nightly.ipa'
 APP: null
 MAC: null
 WIN: null
-SHA: 'https://status-im.ams3.digitaloceanspaces.com/StatusIm-200803-083544-d0ce6f-nightly.sha256'
+SHA: 'https://status-im.ams3.digitaloceanspaces.com/StatusIm-200810-025900-687223-nightly.sha256'

--- a/themes/navy/languages/en.yml
+++ b/themes/navy/languages/en.yml
@@ -553,7 +553,7 @@ site:
         description: "At only 29€, Keycard provides strong hardware security guarantees, without the expensive price tag."
         link: "Get a Keycard 29€"
     faq:
-      title: "Do you have qestions?"
+      title: "Do you have questions?"
       button: "Learn More"
   keycard:
     intro:
@@ -570,7 +570,7 @@ site:
       description: "Added greater security and require Keycard + PIN entry as two-factor authentication to log into your Status Account."
       confirmed: "Successfully login"
     faq:
-      title: "Do you have qestions?"
+      title: "Do you have questions?"
       button: "Visit FAQ"
   faq:
     title: "F.A.Q"

--- a/themes/navy/languages/en.yml
+++ b/themes/navy/languages/en.yml
@@ -85,6 +85,9 @@ site:
         title: "Implementation"
       communication-post-mortem:
         title: "Communication & Post-mortem"
+    quarterly-reports:
+      title: "The Status Network Quarterly Reports"
+      description: "We can’t wait to share with you everything that we’ve accomplished."
     join-us:
       title: "Join us"
     core-contributors:

--- a/themes/navy/layout/about.ejs
+++ b/themes/navy/layout/about.ejs
@@ -73,7 +73,7 @@
 	</section>
 	<!-- END-ABOUT-PRINCIPLES -->
 
-	<!-- ABOUT-CHAT -->
+	<!-- ABOUT-HOW-WE-WORK -->
 	<section class="bg-blue-gray-light mt-64" id="how-we-work">
 		<div class="max-w-screen-2xl mx-auto px-4 py-40 2xl:py-64 lg:px-12 xl:px-24">
 			<h3 class="font-display text-4xl xl:text-6xl"><%- __('site.about.how-we-work.title') %></h3>
@@ -96,7 +96,57 @@
 	</section>
 	<!-- END-ABOUT-CHAT -->
 
-	<!-- ABOUT-CORE-CONTRIBUTORS -->
+	<!-- ABOUT-QUARTERLY-REPORTS -->
+	<section class="mt-64 max-w-screen-2xl mx-auto px-4 lg:px-12 mb-64" id="quarterly-reports">
+		<h3 class="font-display text-4xl xl:text-6xl"><%- __('site.about.quarterly-reports.title') %></h3>
+		<p class="text-gray-900 mt-12 text-xl xl:text-3xl font-display font-medium leading-normal"><%- __('site.about.quarterly-reports.description') %></p>
+		<div class="grid md:grid-cols-3 gap-12">
+			<div>
+				<div class="accordion bg-primary-100 mt-12 p-6">
+					<div>
+						<a href="#" class="text-2xl collapsed flex items-center justify-between custom-accordion-trigger" data-toggle="collapse" data-target="#quarterly-reports-2020" aria-expanded="false" aria-controls="#quarterly-reports-2020">
+							2020
+							<span class="ml-8 text-primary-800 custom-accordion-arrow"><%- image_tag('/img/icon-arrow-down.svg') %></span>
+						</a>
+						<div id="quarterly-reports-2020" class="mt-8 hidden text-gray-500 collapse accordion-content">
+							<div class="description">
+								<div class="mt-4">
+									<a href="https://drive.google.com/uc?export=download&id=1PSKeuzesqv3ZahJqsT1q7cJNjant8eMG" download="Q1_2020" class="text-primary-base">- Q1 Quarterly Report</a>
+								</div>
+								<div class="mt-4">
+									<a href="https://drive.google.com/uc?export=download&id=1JnICpK0tzAokNy47rABiZtdFE1VuE4vj" download="Q2_2020" class="text-primary-base">- Q2 Quarterly Report</a>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div class="accordion bg-primary-100 mt-12 p-6">
+					<div>
+						<a href="#" class="text-2xl collapsed flex items-center justify-between custom-accordion-trigger" data-toggle="collapse" data-target="#quarterly-reports-2019" aria-expanded="false" aria-controls="#quarterly-reports-2019">
+							2019
+							<span class="ml-8 text-primary-800 custom-accordion-arrow"><%- image_tag('/img/icon-arrow-down.svg') %></span>
+						</a>
+						<div id="quarterly-reports-2019" class="mt-8 hidden text-gray-500 collapse accordion-content">
+							<div class="description">
+								<div class="mt-4">
+									<a href="https://drive.google.com/uc?export=download&id=1tXK_LD58CKY4UwTqqi446eeV0sTzvRtz" download="Q2_2019" class="text-primary-base">- Q2 Quarterly Report</a>
+								</div>
+								<div class="mt-4">
+									<a href="https://drive.google.com/uc?export=download&id=17Z3sjsJ0LaI-2bcefPzD_IZttz5ap6KQ" download="Q3_2019" class="text-primary-base">- Q3 Quarterly Report</a>
+								</div>
+								<div class="mt-4">
+									<a href="https://drive.google.com/uc?export=download&id=1KOGILq_-V1oh98GXn8b2_Q1SXEWpGAzC" download="Q4_2019" class="text-primary-base">- Q4 Quarterly Report</a>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</section>
+	<!-- END-ABOUT-CHAT -->
+
+	<!-- ABOUT-QUARTERLY-REPORTS -->
 	<section class="mt-40 max-w-screen-2xl mx-auto px-4 lg:px-12 xl:px-24 mb-64" id="core-contributors">
 			<h3 class="font-display text-4xl xl:text-6xl"><%- __('site.about.core-contributors.title') %></h3>
 			<p class="text-gray-600 mt-8 text-lg 2xl:text-3xl font-display font-medium leading-normal"><%- __('site.about.core-contributors.description') %></p>


### PR DESCRIPTION
Add quarterly reports to the About page as per Ceri & Jonny's request
<img width="1716" alt="Screen Shot 2020-08-11 at 12 02 26 AM" src="https://user-images.githubusercontent.com/41753422/89797556-08dbef80-db66-11ea-8153-5cc214e2835a.png">

Preview: https://dev-lang.status.im/about/