### PR TITLE
Fix a wrong translation key on the FAQ page

### DIFF
--- a/source/_data/faq.yml
+++ b/source/_data/faq.yml
@@ -40,7 +40,7 @@
       - question: 'site.faq.keys-and-accounts.q3.question'
         answer: 'site.faq.keys-and-accounts.q3.answer'
     - - question: 'site.faq.keys-and-accounts.q2.question'
-        answer: 'site.faq.general.q2.answer'
+        answer: 'site.faq.keys-and-accounts.q2.answer'
       - question: 'site.faq.keys-and-accounts.q4.question'
         answer: 'site.faq.keys-and-accounts.q4.answer'
 

--- a/themes/navy/layout/about.ejs
+++ b/themes/navy/layout/about.ejs
@@ -75,7 +75,7 @@
 
 	<!-- ABOUT-HOW-WE-WORK -->
 	<section class="bg-blue-gray-light mt-64" id="how-we-work">
-		<div class="max-w-screen-2xl mx-auto px-4 py-40 2xl:py-64 lg:px-12 xl:px-20">
+		<div class="max-w-screen-2xl mx-auto px-12 py-40 2xl:py-64 lg:px-12 xl:px-20">
 			<h3 class="font-display text-4xl xl:text-6xl"><%- __('site.about.how-we-work.title') %></h3>
 			<p class="text-gray-600 mt-8 text-lg 2xl:text-3xl font-display font-medium leading-normal"><%- __('site.about.how-we-work.description') %></p>
 			<div class="mt-64">


### PR DESCRIPTION
**Fix a wrong translation key.**

Replaced `site.faq.general.q2.answer` with `site.faq.keys-and-accounts.q2.answer`


In addition, there is a minor padding CSS change on the update page for mobile.

Before
<img width="280" alt="Screen Shot 2020-10-27 at 10 22 30 PM" src="https://user-images.githubusercontent.com/41753422/97307352-ec1ca180-18a2-11eb-92bd-96e758df4071.png">

After
<img width="279" alt="Screen Shot 2020-10-27 at 10 22 08 PM" src="https://user-images.githubusercontent.com/41753422/97307356-ed4dce80-18a2-11eb-918b-0f33addc835c.png">