### PR TITLE
drop use of GreenHouse JS and just embed the IFrame directly

### DIFF
--- a/source/contribute/open_positions.md
+++ b/source/contribute/open_positions.md
@@ -1,17 +1,1 @@
----
-id: open_positions
-title: Open Positions
-description: We welcome contributors from all over the globe
----
-
-# Open Positions
-
-Please note that all of our positions are remote - we welcome contributors from all over the globe.
- 
-<div id="grnhse_app"></div>
-<script src="https://boards.greenhouse.io/embed/job_board/js?for=status72"></script>
-
-
-If you believe you can contribute, but don't see a role that closely matches your skills - please send a short note and your CV to talent@status.im.
-
-Want to chat to our People Ops team? Drop by the [#hiring](https://discord.gg/ncDjzk2) channel on our community Discord, or check out the latest project discussions over at [discuss.status.im](https://discuss.status.im) :) 
+source/our_team/open_positions.md

--- a/source/our_team/open_positions.md
+++ b/source/our_team/open_positions.md
@@ -8,5 +8,11 @@ description: Check out our open positions.
 
 Please note that all of our positions are remote - we welcome contributors from all over the globe. Want to chat to our People Ops team? Drop by the [#hiring](https://discord.gg/ncDjzk2) channel on our community Discord, or check out the latest project discussions over at [discuss.status.im](https://discuss.status.im) :) 
  
-<div id="grnhse_app"></div>
-<script src="https://boards.greenhouse.io/embed/job_board/js?for=status72"></script>
+<div class="grid grid-cols-4 sm:grid-cols-2 xl:grid-cols-6">
+<div class="col-span-1"></div>
+<iframe id="greenhouse-job-board" class="col-span-2 xl:col-span-4" height="600em" width="100%" src="https://boards.greenhouse.io/embed/job_board?for=status72" title="GreenHouse Job Board"></iframe>
+</div>
+
+If you believe you can contribute, but don't see a role that closely matches your skills - please send a short note and your CV to talent@status.im.
+
+Want to chat to our People Ops team? Drop by the [#hiring](https://discord.gg/ncDjzk2) channel on our community Discord, or check out the latest project discussions over at [discuss.status.im](https://discuss.status.im) :) 


### PR DESCRIPTION
This avoids a possible exploit using URL arguments to specify an alternative jobs board like so:
https://status.im/our_team/open_positions.html?gh_jid=2223984;for=remitly

Also, I hate CSS.