### PR TITLE
add instructions for installing desktop beta

### DIFF
--- a/source/_data/sidebar.yml
+++ b/source/_data/sidebar.yml
@@ -58,6 +58,8 @@ docs:
         path: pairing_devices.html
       - title: Security Best Practices
         path: best_security_practices.html
+      - title: Desktop Beta Installation
+        path: ../user_guides/desktop_beta_install.html
 
   - title: Audits
     path: audits/

--- a/source/user_guides/desktop_beta_install.md
+++ b/source/user_guides/desktop_beta_install.md
@@ -1,0 +1,25 @@
+---
+id: Desktop Beta Installation
+title: Desktop Beta Installation Instructions
+layout: tutorials
+---
+
+Due to the app being still in Beta, some manual steps are required to install or upgrade the App.
+
+## MacOS
+
+* Open the Finder and in its menu click `Go`.
+* Select `Go To Folder...` and enter `~/Library/Application Support/Status`.
+* Backup this folder somewhere else if you need it.
+* Remove the folder and copy `Status.app` from the opened `Status.dmg` to the Applications folder.
+
+## Linux
+
+* Backup the `~/.config/Status` directory if you need it.
+* Delete the `~/.config/Status` directory.
+
+## Windows
+
+* Press the Start button, select `Run` (or Windows Key + R) and type: `%LOCALAPPDATA%\Status`.
+* Backup this folder somewhere else if you need it.
+* After backup, remove the folder and move the unzipped Status folder to your preferred location.

--- a/source/user_guides/index.md
+++ b/source/user_guides/index.md
@@ -8,3 +8,4 @@ You might find some of the articles available here helpful:
 
 * [Pairing Devices](./pairing_devices.html) - How to pair devices to keep channels and contacts synced between them.
 * [Security Best Practices](./best_security_practices.html) - What are the best practices to keep your account secure.
+* [Desktop App Installation](./desktop_beta_install.html) - Manual instructions for installing and upgrading the desktop app.

--- a/themes/navy/languages/en.yml
+++ b/themes/navy/languages/en.yml
@@ -503,6 +503,7 @@ site:
     desktop:
       title: "Desktop"
       description: "Test out Desktop Beta for private, secure communication where you work."
+      instructions: "* Read the installation instructions <u>here</u>."
   landing-page-v1:
     intro:
       private-messaging:

--- a/themes/navy/layout/get.ejs
+++ b/themes/navy/layout/get.ejs
@@ -46,6 +46,11 @@
                 <span class="ml-4">Linux</span>
               </a>
             </div>
+            <p class="text-xl text-center italic mt-2 lg:px-20">
+              <a href="/user_guides/desktop_beta_install.html">
+                <%- __('site.get.desktop.instructions') %>
+              </a>
+            </p>
             <div class="mt-16 mx-auto text-center -mb-16 lg:-mb-64">
               <%- image_tag("/img/desktop-app-laptop.png") %>
             </div>


### PR DESCRIPTION
Examples:
https://a71723e20feb.eu.ngrok.io/get/
https://a71723e20feb.eu.ngrok.io/user_guides/
https://a71723e20feb.eu.ngrok.io/user_guides/desktop_beta_install.html

I added a link under the download buttons:
![image](https://user-images.githubusercontent.com/2212681/104331689-a493d200-54ef-11eb-8636-0897ce7a7847.png)

I was hoping maybe @jrainville could help me make the link to instructions on `/get/` page look a bit more clickable.
I'm absolute garbage at CSS and making style changes.