### PR TITLE
Remove Android only copy of Keycard

### DIFF
--- a/source/_data/nightlies.yml
+++ b/source/_data/nightlies.yml
@@ -1,7 +1,7 @@
-DIAWI: 'https://i.diawi.com/CBUf6W'
-APK: 'https://status-im-nightlies.ams3.digitaloceanspaces.com/StatusIm-210310-055900-51178a-nightly-universal.apk'
-IOS: 'https://status-im-nightlies.ams3.digitaloceanspaces.com/StatusIm-210310-055900-51178a-nightly.ipa'
+DIAWI: 'https://i.diawi.com/2AkcYZ'
+APK: 'https://status-im-nightlies.ams3.digitaloceanspaces.com/StatusIm-210318-055900-4e0ec3-nightly-universal.apk'
+IOS: 'https://status-im-nightlies.ams3.digitaloceanspaces.com/StatusIm-210318-055900-4e0ec3-nightly.ipa'
 APP: null
 MAC: null
 WIN: null
-SHA: 'https://status-im-nightlies.ams3.digitaloceanspaces.com/StatusIm-210310-055900-51178a-nightly.sha256'
+SHA: 'https://status-im-nightlies.ams3.digitaloceanspaces.com/StatusIm-210318-055900-4e0ec3-nightly.sha256'

--- a/themes/navy/languages/en.yml
+++ b/themes/navy/languages/en.yml
@@ -525,7 +525,7 @@ site:
   keycard-integration:
     intro:
       title: "Add Hardware Security to Your Status Experience"
-      description: "Protect your assets and accounts with Keycard - the cold storage hardware wallet with a contactless, convenient experience. Android only."
+      description: "Protect your assets and accounts with Keycard - the cold storage hardware wallet with a contactless, convenient experience."
       button: "Get a Keycard 29€"
     about:
       title: "What is Keycard?"


### PR DESCRIPTION
As Keycard support iOS from 1.12, removed "Android only" from the Keycard page