### PR TITLE
rename Open Positions page to Jobs for better visibility

### DIFF
--- a/_config.dev.yml
+++ b/_config.dev.yml
@@ -77,4 +77,5 @@ alias:
   feature-request/index.html: https://docs.google.com/forms/d/1AD9HBVLUfztKx3erB5LBBYorbYgrVCRd2OnEtICMDqc/
   roadmap/index.html: https://trello.com/b/DkxQd1ww/status-app-roadmap
   stickers/index.html: https://forms.gle/2czVVRjPtWmTMJSq7
-  contribute/open_positions.html: https://dev.status.im/our_team/open_positions.html
+  contribute/open_positions.html: https://dev.status.im/our_team/jobs.html
+  our_team/open_positions.html: https://dev.status.im/our_team/jobs.html

--- a/_config.prod.yml
+++ b/_config.prod.yml
@@ -74,4 +74,5 @@ alias:
   feature-request/index.html: https://docs.google.com/forms/d/1AD9HBVLUfztKx3erB5LBBYorbYgrVCRd2OnEtICMDqc/
   roadmap/index.html: https://trello.com/b/DkxQd1ww/status-app-roadmap
   stickers/index.html: https://forms.gle/2czVVRjPtWmTMJSq7
-  contribute/open_positions.html: https://status.im/our_team/open_positions.html
+  contribute/open_positions.html: https://status.im/our_team/jobs.html
+  our_team/open_positions.html: https://status.im/our_team/jobs.html

--- a/source/_data/sidebar.yml
+++ b/source/_data/sidebar.yml
@@ -67,12 +67,12 @@ docs:
   - title: Join the team
     path: our_team
     children:
+      - title: Jobs at Status
+        path: jobs.html
       - title: FAQs
         path: faqs.html
       - title: Our Principles
         path: our_principles.html
-      - title: Open Positions
-        path: open_positions.html
       - title: Applying
         path: applying_to_status.html
       - title: Applicant Privacy

--- a/source/our_team/jobs.md
+++ b/source/our_team/jobs.md
@@ -1,10 +1,10 @@
 ---
-id: open_positions
-title: Open Positions
+id: jobs
+title: Jobs at Status
 description: Check out our open positions.
 ---
 
-# Open Positions
+# Jobs at Status
 
 Please note that all of our positions are remote - we welcome contributors from all over the globe. Want to chat to our People Ops team? Drop by the [#hiring](https://discord.gg/ncDjzk2) channel on our community Discord, or check out the latest project discussions over at [discuss.status.im](https://discuss.status.im) :) 
  

--- a/themes/navy/layout/about.ejs
+++ b/themes/navy/layout/about.ejs
@@ -93,8 +93,8 @@
 				</ul>
 			</div>
 			<div class="">
-				<a href="<%- show_lang() %>/our_team/open_positions.html" class="group inline-flex group items-center text-primary-base text-lg 2xl:text-2xl font-semibold font-special mt-24">
-					<%- __('site.footer.status.open_positions') %>
+				<a href="<%- show_lang() %>/our_team/jobs.html" class="group inline-flex group items-center text-primary-base text-lg 2xl:text-2xl font-semibold font-special mt-24">
+					<%- __('site.footer.status.jobs') %>
 					<span class="ml-4 group-hover:translate-x-1 transform transition-all duration-200 linear"><%- image_tag('/img/icon-arrow-right.svg') %></span>
 				</a>
 			</div>
@@ -163,7 +163,7 @@
 			<h3 class="font-display text-4xl xl:text-6xl"><%- __('site.about.core-contributors.title') %></h3>
 			<p class="text-gray-600 mt-8 text-lg 2xl:text-3xl font-display font-medium leading-normal"><%- __('site.about.core-contributors.description') %></p>
 			<!-- <ul class="inline-links">
-				<li><a href="<%- show_lang() %>/contribute/open_positions.html" class="link-arrow"><%- __('site.about.core-contributors.link-1') %></a></li>
+				<li><a href="<%- show_lang() %>/contribute/jobs.html" class="link-arrow"><%- __('site.about.core-contributors.link-1') %></a></li>
 				<li><a href="<%- show_lang() %>/contribute/life_status.html" class="link-arrow"><%- __('site.about.core-contributors.link-2') %></a></li>
 			</ul> -->
 			

--- a/themes/navy/layout/partial/footer.ejs
+++ b/themes/navy/layout/partial/footer.ejs
@@ -51,7 +51,7 @@
                         <li class="mt-4"><a href="https://our.status.im/"><%- __('site.header.nav.blog') %></a></li>
                         <li class="mt-4"><a href="/files/whitepaper.pdf" target="_blank"><%- __('site.footer.status.white-paper') %></a></li>
                         <li class="mt-4"><a href="https://analytics.status.im/" target="_blank"><%- __('site.footer.status.analytics') %></a></li>
-                        <li class="mt-4"><a href="/our_team/open_positions.html" target="_blank"><%- __('site.footer.status.open_positions') %></a></li>
+                        <li class="mt-4"><a href="/our_team/jobs.html" target="_blank"><%- __('site.footer.status.jobs') %></a></li>
                     </ul>
                 </div>
             </div>

--- a/themes/navy/layout/partial/header.ejs
+++ b/themes/navy/layout/partial/header.ejs
@@ -68,8 +68,8 @@
                             <div class="mt-4 pl-12">
                                 <ul class="flex items-center flex-wrap">
                                     <li class="w-1/2">
-                                      <a href="<%- show_lang() %>/docs/" class="flex items-center text-gray-900 group">
-                                        <%- __('site.link.developers') %>
+                                      <a href="<%- show_lang() %>/our_team/jobs.html" class="flex items-center text-gray-900 group">
+                                        <%- __('site.footer.status.jobs') %>
                                         <span class="ml-4 group-hover:translate-x-1 transform transition-all duration-200 linear"><%- image_tag('/img/icon-arrow-right.svg') %></span>
                                       </a>
                                     </li>
@@ -129,8 +129,8 @@
                                     </li>
                                     <li class="w-1/2"></li>
                                     <li class="mt-8 w-1/2">
-                                      <a href="<%- show_lang() %>/our_team/open_positions.html" class="flex items-center text-gray-900 group">
-                                        <%- __('site.footer.status.open_positions') %>
+                                      <a href="<%- show_lang() %>/docs/" class="flex items-center text-gray-900 group">
+                                        <%- __('site.link.developers') %>
                                         <span class="ml-4 group-hover:translate-x-1 transform transition-all duration-200 linear"><%- image_tag('/img/icon-arrow-right.svg') %></span>
                                       </a>
                                     </li>

--- a/themes/navy/source/js/main.js
+++ b/themes/navy/source/js/main.js
@@ -502,7 +502,7 @@ $(document).ready(function($) {
     $('.js-editor-content h1, .js-editor-content h2, .js-editor-content h3').each(function (index, element) {
       var id = $(this).attr('id');
       var title = $(this).text();
-      if (title === 'Open Positions') {
+      if (title === 'Jobs at Status') {
         $('.js-right-sub-navigation').css("display", "none");
         return false;
       }


### PR DESCRIPTION
Because apparently some found it hard to fine the `Open Positions` page.

![image](https://user-images.githubusercontent.com/2212681/112824829-4d7fb100-908b-11eb-8072-cdb05f743d20.png)