### PR TITLE
Remove a line from the jobs page

### DIFF
--- a/source/our_team/jobs.md
+++ b/source/our_team/jobs.md
@@ -10,5 +10,3 @@ Please note that all of our positions are remote - we welcome contributors from 
  
 <div id="grnhse_app"></div>
 <script src="https://boards.greenhouse.io/embed/job_board/js?for=status72"></script>
-
-If you believe you can contribute, but don't see a role that closely matches your skills - please send a short note and your CV to talent@status.im.


### PR DESCRIPTION
Removed 
```If you believe you can contribute, but don’t see a role that closely matches your skills - please send a short note and your CV to talent@status.im.``` 

as per the peopleops team's request