### PR TITLE
Add the Q1 2021 quarterly report

### DIFF
--- a/source/_data/nightlies.yml
+++ b/source/_data/nightlies.yml
@@ -1,7 +1,7 @@
-DIAWI: 'https://i.diawi.com/eF9X9v'
-APK: 'https://status-im-nightlies.ams3.digitaloceanspaces.com/StatusIm-210727-055900-db68c3-nightly-universal.apk'
-IOS: 'https://status-im-nightlies.ams3.digitaloceanspaces.com/StatusIm-210727-055900-db68c3-nightly.ipa'
+DIAWI: 'https://i.diawi.com/1fLEkb'
+APK: 'https://status-im-nightlies.ams3.digitaloceanspaces.com/StatusIm-210729-055900-9a61ef-nightly-universal.apk'
+IOS: 'https://status-im-nightlies.ams3.digitaloceanspaces.com/StatusIm-210729-055900-9a61ef-nightly.ipa'
 APP: null
 MAC: null
 WIN: null
-SHA: 'https://status-im-nightlies.ams3.digitaloceanspaces.com/StatusIm-210727-055900-db68c3-nightly.sha256'
+SHA: 'https://status-im-nightlies.ams3.digitaloceanspaces.com/StatusIm-210729-055900-9a61ef-nightly.sha256'

--- a/themes/navy/layout/about.ejs
+++ b/themes/navy/layout/about.ejs
@@ -110,6 +110,21 @@
 			<div>
 				<div class="accordion bg-primary-100 mt-12 p-6">
 					<div>
+						<a href="#" class="text-2xl collapsed flex items-center justify-between custom-accordion-trigger" data-toggle="collapse" data-target="#quarterly-reports-2021" aria-expanded="false" aria-controls="#quarterly-reports-2021">
+							2021
+							<span class="ml-8 text-primary-800 custom-accordion-arrow"><%- image_tag('/img/icon-arrow-down.svg') %></span>
+						</a>
+						<div id="quarterly-reports-2021" class="mt-8 hidden text-gray-500 collapse accordion-content">
+							<div class="description">
+								<div class="mt-4">
+									<a href="https://drive.google.com/uc?export=download&id=1p-ZA_yDKcaJcM8nftW2i7hVBBNUE9cv1" download="Q1_2020" class="text-primary-base">- Q1 Quarterly Report</a>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div class="accordion bg-primary-100 mt-12 p-6">
+					<div>
 						<a href="#" class="text-2xl collapsed flex items-center justify-between custom-accordion-trigger" data-toggle="collapse" data-target="#quarterly-reports-2020" aria-expanded="false" aria-controls="#quarterly-reports-2020">
 							2020
 							<span class="ml-8 text-primary-800 custom-accordion-arrow"><%- image_tag('/img/icon-arrow-down.svg') %></span>


### PR DESCRIPTION
<img width="778" alt="Screen Shot 2021-07-30 at 1 03 20 AM" src="https://user-images.githubusercontent.com/41753422/127526055-88f05887-62d2-437a-910e-09dab4572e81.png">

Added the Q1 2021 quarterly report to the `about` page