### PR TITLE
Add a CTA for Status Node doc

### DIFF
--- a/themes/navy/languages/en.yml
+++ b/themes/navy/languages/en.yml
@@ -240,6 +240,7 @@ site:
         box-3:
           title: "Can utilize cloud providers such as AWS or Azure."
           number: "3"
+      learn-more: "Learn how to run a Status Node here"
     join:
       title: "Join"
       status-nodes-link: "#status-node-runners"

--- a/themes/navy/layout/status-nodes.ejs
+++ b/themes/navy/layout/status-nodes.ejs
@@ -278,6 +278,21 @@
 					</h4>
 				</div>
 			</div>
+			<div class="flex justify-center m-auto">
+				<a href="https://status.im/technical/run_status_node.html" target="_blank"
+					class="group flex justify-between mt-16 xl:mt-20 border transition-all duration-200 linear font-special font-bold transition-all linear rounded py-4 px-5 inline-flex text-black border-black hover:bg-black hover:text-white"
+					style="min-width: 210px;">
+					<%- __('site.status-nodes.requirements.learn-more') %>
+					<span
+						class="pl-4 pr-4 group-hover:translate-x-1 transform transition-all my-auto duration-200 linear">
+						<svg width="6" height="13" viewBox="0 0 6 13" xmlns="http://www.w3.org/2000/svg">
+							<path opacity="1" fill-rule="evenodd" clip-rule="evenodd"
+								d="M4.001 6.00098L0 12.001H2L6.001 6.00098L2 -2.38419e-05H0L4.001 6.00098Z"
+								fill="currentColor"></path>
+						</svg>
+					</span>
+				</a>
+			</div>
 		</div>
 	</section>
 


### PR DESCRIPTION
Added a CTA as per request

Screenshot: 
<img width="1791" alt="Screen Shot 2021-08-11 at 1 48 31 AM" src="https://user-images.githubusercontent.com/41753422/128900465-4b2ae5da-7440-4288-8973-2059e033bf5f.png">
