### PR TITLE
improve link ux on faq pages

### DIFF
--- a/themes/navy/source/scss/main.scss
+++ b/themes/navy/source/scss/main.scss
@@ -263,6 +263,10 @@ td:nth-child(1) {
   transform: rotate(90deg);
 }
 
+div.description a {
+  text-decoration: underline !important;
+  color: -webkit-link !important;
+}
 
 // Importing Vendored Keycard SCSS
 @import 'animations';


### PR DESCRIPTION
All a tags inside FAQs  will now appear as links.
I have added the css selector in the main.scss file to ensure all the links in the answers of FAQ appear as links. ( I mean they have an underline and a blue color which all of us are used to ).
